### PR TITLE
 azure/mip: endringer knyttet til manglende "expires_on"

### DIFF
--- a/http-client/src/main/java/no/nav/familie/http/azure/AccessTokenDto.java
+++ b/http-client/src/main/java/no/nav/familie/http/azure/AccessTokenDto.java
@@ -5,15 +5,15 @@ import java.time.Instant;
 public class AccessTokenDto {
     public String token_type;
     public String access_token;
-    public Instant expires_on;
+    public Integer expires_in;
 
     public AccessTokenDto() {
     }
 
-    public AccessTokenDto(String token_type, String access_token, Instant expires_on) {
+    public AccessTokenDto(String token_type, String access_token, Integer expires_in) {
         this.token_type = token_type;
         this.access_token = access_token;
-        this.expires_on = expires_on;
+        this.expires_in = expires_in;
     }
 
     public String getToken_type() {
@@ -24,7 +24,7 @@ public class AccessTokenDto {
         return access_token;
     }
 
-    Instant getExpires_on() {
-        return expires_on;
+    Integer getExpires_in() {
+        return expires_in;
     }
 }


### PR DESCRIPTION
- opprett det absolutte tidspunktet tokenet utløper
- dette lagres i klientklassen da vi ikke lenger får dette fra endepunktet

(strekker også varigheten til tokenet litt lenger da azure anslagsvis er litt mer stabilt)