### PR TITLE
Benytte callId fra context hvis satt

### DIFF
--- a/log/src/main/java/no/nav/familie/log/filter/LogFilter.java
+++ b/log/src/main/java/no/nav/familie/log/filter/LogFilter.java
@@ -65,9 +65,13 @@ public class LogFilter implements Filter {
         }
 
         String consumerId = httpServletRequest.getHeader(CONSUMER_ID_HEADER_NAME);
-        String callId = resolveCallId(httpServletRequest);
+        String callId = MDC.get(MDC_CALL_ID);
 
-        MDC.put(MDC_CALL_ID, callId);
+        if (callId == null) {
+            callId = resolveCallId(httpServletRequest);
+            MDC.put(MDC_CALL_ID, callId);
+        }
+
         MDC.put(MDC_USER_ID, userId);
         MDC.put(MDC_CONSUMER_ID, consumerId);
         MDC.put(MDC_REQUEST_ID, generateId());


### PR DESCRIPTION
Kan det være hensiktsmessig å sjekke om vi har en callId før vi genererer ny? Om jeg har forstått det rett vil det nå automatisk genereres callId for hver nye request fra contexten dersom vi ikke eksplisitt setter gjeldende callId på request (som vi jo gjør, men da slipper vi det). 

Skal ikke påvirke bruk, utover at man kan la være å sette callId på nye requests, men likevel klare å propagere den videre. 