### PR TITLE
Generalisere pakkenavn

### DIFF
--- a/kontrakt/src/main/java/no/nav/familie/kontrakt/Ressurs.kt
+++ b/kontrakt/src/main/java/no/nav/familie/kontrakt/Ressurs.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.sak.kontrakt
+package no.nav.familie.kontrakt
 
 import java.io.PrintWriter
 import java.io.StringWriter
@@ -17,17 +17,18 @@ data class Ressurs<T>(
 
         fun <T> success(data: T, melding: String? = null): Ressurs<T> =
                 Ressurs(data,
-                        Status.SUKSESS,
-                        melding ?: "Innhenting av data var vellykket",
-                        null)
+                                                                   Status.SUKSESS,
+                                                                   melding ?: "Innhenting av data var vellykket",
+                                                                   null)
 
         fun <T> failure(errorMessage: String? = null, error: Throwable? = null): Ressurs<T> =
                 Ressurs(null,
-                        Status.FEILET,
-                        errorMessage ?: "Kunne ikke hente data: ${error?.message}",
-                        error?.textValue())
+                                                                   Status.FEILET,
+                                                                   errorMessage ?: "Kunne ikke hente data: ${error?.message}",
+                                                                   error?.textValue())
 
-        fun <T> ikkeTilgang(melding: String): Ressurs<T> = Ressurs(null,
+        fun <T> ikkeTilgang(melding: String): Ressurs<T> =
+                Ressurs(null,
                                                                    Status.IKKE_TILGANG,
                                                                    melding,
                                                                    null)

--- a/prosessering/src/main/java/no/nav/familie/prosessering/rest/RestTaskService.kt
+++ b/prosessering/src/main/java/no/nav/familie/prosessering/rest/RestTaskService.kt
@@ -4,7 +4,7 @@ import no.nav.familie.prosessering.domene.Avvikstype
 import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.domene.TaskRepository
-import no.nav.familie.sak.kontrakt.Ressurs
+import no.nav.familie.kontrakt.Ressurs
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service

--- a/prosessering/src/main/java/no/nav/familie/prosessering/rest/TaskController.kt
+++ b/prosessering/src/main/java/no/nav/familie/prosessering/rest/TaskController.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.prosessering.rest
 
 import no.nav.familie.prosessering.domene.Status
-import no.nav.familie.sak.kontrakt.Ressurs
+import no.nav.familie.kontrakt.Ressurs
 import no.nav.familie.sikkerhet.OIDCUtil
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.ResponseEntity


### PR DESCRIPTION
Skal bruke ressurs på kodeverk-endepunktet i `familie-integrasjoner` og ønsker å ta i bruk dette i stedet for å importere fra ks-sak ( `no.nav.familie.ks.kontrakter.sak.Ressurs`) som gjøres ellers. Hvis ønskelig kan vi oppdatere de i sammen slengen.

Tok en kjap prat med Stig - per nå ingen som bruker det enda, så skal gå fint å endre navn