### PR TITLE
Tilgjengeliggjør henting av accesstoken fra dto

### DIFF
--- a/http-client/src/main/java/no/nav/familie/http/azure/AccessTokenDto.java
+++ b/http-client/src/main/java/no/nav/familie/http/azure/AccessTokenDto.java
@@ -19,7 +19,7 @@ public class AccessTokenDto {
         return token_type;
     }
 
-    String getAccess_token() {
+    public String getAccess_token() {
         return access_token;
     }
 


### PR DESCRIPTION
Holder på å ta i bruk nyeste versjon av **familie-felles** i **familie-integrasjoner**. Etter at feltene i `AccessTokenDto` ble satt private klarer ikke lenger infotrygd-integrasjonen å hente token.