### PR TITLE
Timeouts i restTemplateBuilder blir overskrevne av NaisProxyCustomizer

### DIFF
--- a/http-client/src/main/java/no/nav/familie/http/config/NaisProxyCustomizer.kt
+++ b/http-client/src/main/java/no/nav/familie/http/config/NaisProxyCustomizer.kt
@@ -3,9 +3,13 @@ package no.nav.familie.http.config
 import org.apache.http.HttpHost
 import org.apache.http.HttpRequest
 import org.apache.http.client.HttpClient
+import org.apache.http.client.config.RequestConfig
 import org.apache.http.impl.client.HttpClientBuilder
 import org.apache.http.impl.conn.DefaultProxyRoutePlanner
 import org.apache.http.protocol.HttpContext
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.boot.web.client.RestTemplateCustomizer
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory
 import org.springframework.stereotype.Component
@@ -14,11 +18,18 @@ import org.springframework.web.client.RestTemplate
 interface INaisProxyCustomizer : RestTemplateCustomizer
 
 @Component
-class NaisProxyCustomizer : INaisProxyCustomizer {
+class NaisProxyCustomizer(@Value("\${familie.nais.proxy.connectTimeout:15000}") val connectTimeout: Int,
+                          @Value("\${familie.nais.proxy.socketTimeout:15000}") val socketTimeout: Int,
+                          @Value("\${familie.nais.proxy.requestTimeout:15000}") val requestTimeout: Int) : INaisProxyCustomizer {
 
     override fun customize(restTemplate: RestTemplate) {
         val proxy = HttpHost("webproxy-nais.nav.no", 8088)
         val client: HttpClient = HttpClientBuilder.create()
+                .setDefaultRequestConfig(RequestConfig.custom()
+                                                 .setConnectTimeout(connectTimeout)
+                                                 .setSocketTimeout(socketTimeout)
+                                                 .setConnectionRequestTimeout(requestTimeout)
+                                                 .build())
                 .setRoutePlanner(object : DefaultProxyRoutePlanner(proxy) {
 
                     public override fun determineProxy(target: HttpHost,
@@ -29,7 +40,7 @@ class NaisProxyCustomizer : INaisProxyCustomizer {
                     }
                 }).build()
 
-        restTemplate.requestFactory =
-                HttpComponentsClientHttpRequestFactory(client)
+        restTemplate.requestFactory = HttpComponentsClientHttpRequestFactory(client)
     }
+
 }

--- a/http-client/src/main/java/no/nav/familie/http/config/RestTemplateBuilderBean.kt
+++ b/http-client/src/main/java/no/nav/familie/http/config/RestTemplateBuilderBean.kt
@@ -1,17 +1,9 @@
 package no.nav.familie.http.config
 
-import no.nav.familie.http.interceptor.BearerTokenClientInterceptor
-import no.nav.familie.http.interceptor.ConsumerIdClientInterceptor
-import no.nav.familie.http.interceptor.MdcValuesPropagatingClientInterceptor
-import no.nav.familie.http.interceptor.StsBearerTokenClientInterceptor
 import org.springframework.boot.web.client.RestTemplateBuilder
-import org.springframework.boot.web.client.RestTemplateCustomizer
 import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
-import org.springframework.web.client.RestOperations
-
 
 @Suppress("SpringFacetCodeInspection")
 @Configuration

--- a/http-client/src/test/java/no/nav/familie/http/config/RestTemplateBuilderBeanTest.kt
+++ b/http-client/src/test/java/no/nav/familie/http/config/RestTemplateBuilderBeanTest.kt
@@ -1,0 +1,49 @@
+package no.nav.familie.http.config
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.catchThrowable
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.web.client.getForEntity
+import java.net.SocketTimeoutException
+
+internal class RestTemplateBuilderBeanTest {
+
+    private val wireMockServer = WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort())
+    private val port = wireMockServer.port()
+    private val restTemplate = RestTemplateBuilderBean()
+            .restTemplateBuilder(NaisProxyCustomizer(200, 200, 200))
+            .build()
+
+    @BeforeEach
+    fun setUp() {
+        wireMockServer.start()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        wireMockServer.resetAll()
+        wireMockServer.stop()
+    }
+
+    @Test
+    internal fun `delay med 500 kaster exception`() {
+        wireMockServer.stubFor(
+                WireMock.get(WireMock.anyUrl())
+                        .willReturn(WireMock.aResponse().withStatus(200).withFixedDelay(500)))
+        assertThat(catchThrowable { restTemplate.getForEntity<String>("http://localhost:$port") })
+                .hasCauseInstanceOf(SocketTimeoutException::class.java)
+    }
+
+    @Test
+    internal fun `delay med 100 kaster ikke exception`() {
+        wireMockServer.stubFor(
+                WireMock.get(WireMock.anyUrl())
+                        .willReturn(WireMock.aResponse().withFixedDelay(100)))
+        restTemplate.getForEntity<String>("http://localhost:$port")
+    }
+}


### PR DESCRIPTION
Hvis man ikke setter timeouts httpClient automatisk -1 som verdi, som er ca 15 min timeout.
Vi ønsker att man kaster exception før 15. 

I tillegg så overskrever iNaisProxyCustomizer eventuelle timeouts man setter på RestTemplateBuilder.

Hvis man bruker restTemplateBuilder med timeouts så blir timeouts overskrevne pga`RestTemplateBuilder(iNaisProxyCustomizer)`. Build legger til customisers i sluttet, etter att man har satt timeouts, og overskrever disse.

```kotlin
@Bean
fun operations(restTemplateBuilder: RestTemplateBuilder): RestOperations {
restTemplateBuilder
                .setConnectTimeout(Duration.of(30, ChronoUnit.SECONDS)) // blir overskreven av NaisProxyCustomizer
                .setReadTimeout(Duration.of(180, ChronoUnit.SECONDS)) // blir overskreven av NaisProxyCustomizer
                .build()
}
```

Det hadde nog vært mer riktig å sette requestfactory som en del av build. Men det hadde vært en breaking change med nåværende funksjonalitet (noen overskrever NaisProxyCustomizer i tester)
```kotlin
@Bean("naisProxyClient")
    fun naisProxyClient(): HttpClient {
        val proxy = HttpHost("webproxy-nais.nav.no", 8088)
        return HttpClientBuilder.create()
                .setRoutePlanner(object : DefaultProxyRoutePlanner(proxy) {

                    public override fun determineProxy(target: HttpHost,
                                                       request: HttpRequest, context: HttpContext): HttpHost? {
                        return if (target.hostName.contains("microsoft")) {
                            super.determineProxy(target, request, context)
                        } else null
                    }
                }).build()
    }

    @Bean
    fun restTemplateBuilder(@Qualifier("naisProxyClient") httpClient: HttpClient): RestTemplateBuilder {
        return RestTemplateBuilder().requestFactory{ HttpComponentsClientHttpRequestFactory(httpClient) }
    }
    
    // Den som finnes idag og blir "feil"
    @Bean
    fun restTemplateBuilder(iNaisProxyCustomizer: INaisProxyCustomizer): RestTemplateBuilder {
        return RestTemplateBuilder(iNaisProxyCustomizer)
    }
```