### PR TITLE
Renamer TokenValidationFilter då det allerede finnes en bean i token-…

### DIFF
--- a/sikkerhet/src/main/java/no/nav/familie/sikkerhet/ClientTokenValidationFilter.kt
+++ b/sikkerhet/src/main/java/no/nav/familie/sikkerhet/ClientTokenValidationFilter.kt
@@ -14,10 +14,10 @@ import javax.servlet.http.HttpServletResponse
  * @param issuerName default azuread, kan overskreves hvis issuer er eks aad/azure
  * @param logOnly hvis man ønsker å kun logge resultatet men ikke stoppe requesten
  */
-class TokenValidationFilter(private val acceptClientCredential: Boolean = false,
-                            private val acceptOnBehalfOf: Boolean = false,
-                            private val issuerName: String = "azuread",
-                            private val logOnly: Boolean = false) : OncePerRequestFilter() {
+class ClientTokenValidationFilter(private val acceptClientCredential: Boolean = false,
+                                  private val acceptOnBehalfOf: Boolean = false,
+                                  private val issuerName: String = "azuread",
+                                  private val logOnly: Boolean = false) : OncePerRequestFilter() {
 
     override fun doFilterInternal(request: HttpServletRequest,
                                   response: HttpServletResponse,


### PR DESCRIPTION
…support med navnet tokenValidationFilter

Så det feilet når jeg då hade en bean med
```
@Bean
fun tokenValidationFilter(): FilterRegistrationBean<TokenValidationFilter> {
```
Ja, hadde kunnet endre navn, men tenker det er enkelt gjort å gjøre denne feilen og var litt vanskelig å finne ut av