### PR TITLE
Lagt til explicite restTemplates for clientCredential og OnBehalfOf

### DIFF
--- a/http-client/src/main/java/no/nav/familie/http/config/RestTemplateAzure.kt
+++ b/http-client/src/main/java/no/nav/familie/http/config/RestTemplateAzure.kt
@@ -1,6 +1,8 @@
 package no.nav.familie.http.config
 
+import no.nav.familie.http.interceptor.BearerTokenClientCredentialsClientInterceptor
 import no.nav.familie.http.interceptor.BearerTokenClientInterceptor
+import no.nav.familie.http.interceptor.BearerTokenOnBehalfOfClientInterceptor
 import no.nav.familie.http.interceptor.ConsumerIdClientInterceptor
 import no.nav.familie.http.interceptor.InternLoggerInterceptor
 import no.nav.familie.http.interceptor.MdcValuesPropagatingClientInterceptor
@@ -16,7 +18,9 @@ import org.springframework.web.client.RestOperations
 @Import(RestTemplateBuilderBean::class,
         ConsumerIdClientInterceptor::class,
         InternLoggerInterceptor::class,
-        BearerTokenClientInterceptor::class)
+        BearerTokenClientInterceptor::class,
+        BearerTokenClientCredentialsClientInterceptor::class,
+        BearerTokenOnBehalfOfClientInterceptor::class)
 class RestTemplateAzure {
 
     @Bean("azure")
@@ -24,6 +28,26 @@ class RestTemplateAzure {
                               consumerIdClientInterceptor: ConsumerIdClientInterceptor,
                               internLoggerInterceptor: InternLoggerInterceptor,
                               bearerTokenClientInterceptor: BearerTokenClientInterceptor): RestOperations {
+        return restTemplateBuilder.additionalInterceptors(consumerIdClientInterceptor,
+                                                          bearerTokenClientInterceptor,
+                                                          MdcValuesPropagatingClientInterceptor()).build()
+    }
+
+    @Bean("azureClientCredential")
+    fun restTemplateClientCredentialBearer(restTemplateBuilder: RestTemplateBuilder,
+                                           consumerIdClientInterceptor: ConsumerIdClientInterceptor,
+                                           internLoggerInterceptor: InternLoggerInterceptor,
+                                           bearerTokenClientInterceptor: BearerTokenClientCredentialsClientInterceptor): RestOperations {
+        return restTemplateBuilder.additionalInterceptors(consumerIdClientInterceptor,
+                                                          bearerTokenClientInterceptor,
+                                                          MdcValuesPropagatingClientInterceptor()).build()
+    }
+
+    @Bean("azureOnBehalfOf")
+    fun restTemplateOnBehalfOfBearer(restTemplateBuilder: RestTemplateBuilder,
+                                     consumerIdClientInterceptor: ConsumerIdClientInterceptor,
+                                     internLoggerInterceptor: InternLoggerInterceptor,
+                                     bearerTokenClientInterceptor: BearerTokenOnBehalfOfClientInterceptor): RestOperations {
         return restTemplateBuilder.additionalInterceptors(consumerIdClientInterceptor,
                                                           bearerTokenClientInterceptor,
                                                           MdcValuesPropagatingClientInterceptor()).build()

--- a/http-client/src/test/java/no/nav/familie/http/interceptor/BearerTokenClientCredentialsClientInterceptorTest.kt
+++ b/http-client/src/test/java/no/nav/familie/http/interceptor/BearerTokenClientCredentialsClientInterceptorTest.kt
@@ -1,0 +1,46 @@
+package no.nav.familie.http.interceptor
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.catchThrowable
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpRequest
+import org.springframework.http.client.ClientHttpRequestExecution
+import java.net.URI
+
+internal class BearerTokenClientCredentialsClientInterceptorTest {
+
+    private lateinit var bearerTokenClientInterceptor: BearerTokenClientCredentialsClientInterceptor
+
+    private val oAuth2AccessTokenService = mockk<OAuth2AccessTokenService>(relaxed = true)
+
+    @BeforeEach
+    fun setup() {
+        bearerTokenClientInterceptor = BearerTokenClientCredentialsClientInterceptor(oAuth2AccessTokenService,
+                                                                                     clientConfigurationProperties)
+    }
+
+    @Test
+    fun `intercept bruker grant type client credentials`() {
+        val req = mockk<HttpRequest>(relaxed = true, relaxUnitFun = true)
+        every { req.uri } returns (URI("http://firstResource.no"))
+        val execution = mockk<ClientHttpRequestExecution>(relaxed = true)
+
+        bearerTokenClientInterceptor.intercept(req, ByteArray(0), execution)
+
+        verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration["1"]) }
+    }
+
+    @Test
+    fun `intercept skal kaste feil når det ikke finnes en property med gyldig grant type`() {
+        val req = mockk<HttpRequest>(relaxed = true, relaxUnitFun = true)
+        every { req.uri } returns (URI("http://jwtResource.no"))
+        val execution = mockk<ClientHttpRequestExecution>(relaxed = true)
+        assertThat(catchThrowable { bearerTokenClientInterceptor.intercept(req, ByteArray(0), execution) })
+                .hasMessage("could not find oauth2 client config for uri=http://jwtResource.no and grant type=client_credentials")
+    }
+}

--- a/http-client/src/test/java/no/nav/familie/http/interceptor/BearerTokenOnBehalfOfClientInterceptorTest.kt
+++ b/http-client/src/test/java/no/nav/familie/http/interceptor/BearerTokenOnBehalfOfClientInterceptorTest.kt
@@ -1,0 +1,45 @@
+package no.nav.familie.http.interceptor
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpRequest
+import org.springframework.http.client.ClientHttpRequestExecution
+import java.net.URI
+
+internal class BearerTokenOnBehalfOfClientInterceptorTest {
+
+    private lateinit var bearerTokenClientInterceptor: BearerTokenOnBehalfOfClientInterceptor
+
+    private val oAuth2AccessTokenService = mockk<OAuth2AccessTokenService>(relaxed = true)
+
+    @BeforeEach
+    fun setup() {
+        bearerTokenClientInterceptor = BearerTokenOnBehalfOfClientInterceptor(oAuth2AccessTokenService,
+                                                                              clientConfigurationProperties)
+    }
+
+    @Test
+    fun `intercept bruker grant type client credentials`() {
+        val req = mockk<HttpRequest>(relaxed = true, relaxUnitFun = true)
+        every { req.uri } returns (URI("http://firstResource.no"))
+        val execution = mockk<ClientHttpRequestExecution>(relaxed = true)
+
+        bearerTokenClientInterceptor.intercept(req, ByteArray(0), execution)
+
+        verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration["2"]) }
+    }
+
+    @Test
+    fun `intercept skal kaste feil når det ikke finnes en property med gyldig grant type`() {
+        val req = mockk<HttpRequest>(relaxed = true, relaxUnitFun = true)
+        every { req.uri } returns (URI("http://clientResource.no"))
+        val execution = mockk<ClientHttpRequestExecution>(relaxed = true)
+        Assertions.assertThat(Assertions.catchThrowable { bearerTokenClientInterceptor.intercept(req, ByteArray(0), execution) })
+                .hasMessage("could not find oauth2 client config for uri=http://clientResource.no and grant type=urn:ietf:params:oauth:grant-type:jwt-bearer")
+    }
+}

--- a/http-client/src/test/java/no/nav/familie/http/interceptor/ClientConfigTestProperties.kt
+++ b/http-client/src/test/java/no/nav/familie/http/interceptor/ClientConfigTestProperties.kt
@@ -1,0 +1,41 @@
+package no.nav.familie.http.interceptor
+
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod
+import no.nav.security.token.support.client.core.ClientAuthenticationProperties
+import no.nav.security.token.support.client.core.ClientProperties
+import no.nav.security.token.support.client.core.OAuth2GrantType
+import no.nav.security.token.support.client.spring.ClientConfigurationProperties
+import java.net.URI
+
+private val tokenEndpoint = "http://tokenendpoint.com"
+private val authentication = ClientAuthenticationProperties("clientIdent",
+                                                    ClientAuthenticationMethod.CLIENT_SECRET_BASIC,
+                                                    "Secrets are us",
+                                                    null)
+val clientConfigurationProperties =
+        ClientConfigurationProperties(
+                mapOf("1" to ClientProperties(URI(tokenEndpoint),
+                                              URI(tokenEndpoint),
+                                              OAuth2GrantType.CLIENT_CREDENTIALS,
+                                              listOf("z", "y", "x"),
+                                              authentication,
+                                              URI("http://firstResource.no"), null),
+                      "2" to ClientProperties(URI(tokenEndpoint),
+                                              URI(tokenEndpoint),
+                                              OAuth2GrantType.JWT_BEARER,
+                                              listOf("c", "b", "a"),
+                                              authentication,
+                                              URI("http://firstResource.no"), null),
+                      "3" to ClientProperties(URI(tokenEndpoint),
+                                              URI(tokenEndpoint),
+                                              OAuth2GrantType.JWT_BEARER,
+                                              listOf("z", "y", "x"),
+                                              authentication,
+                                              URI("http://jwtResource.no"), null),
+                      "4" to ClientProperties(URI(tokenEndpoint),
+                                              URI(tokenEndpoint),
+                                              OAuth2GrantType.CLIENT_CREDENTIALS,
+                                              listOf("z", "y", "x"),
+                                              authentication,
+                                              URI("http://clientResource.no"), null))
+        )


### PR DESCRIPTION
Lagt til explicit restTemplate med interceptor for
* ClientCredentials
* OnBehalfOf

Det fordi når vi kaller pdl så kan det være fint å explicit bruke den ene eller den andre, beroende på hva man skal hente.