### PR TITLE
Endrer tilbake BearerTokenClientInterceptor til å bruke første client…

### DIFF
--- a/http-client/src/main/java/no/nav/familie/http/interceptor/BearerTokenClientInterceptor.kt
+++ b/http-client/src/main/java/no/nav/familie/http/interceptor/BearerTokenClientInterceptor.kt
@@ -3,7 +3,6 @@ package no.nav.familie.http.interceptor
 import no.nav.familie.http.sts.StsRestClient
 import no.nav.security.token.support.client.core.ClientProperties
 import no.nav.security.token.support.client.core.OAuth2GrantType
-import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenResponse
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
 import no.nav.security.token.support.client.spring.ClientConfigurationProperties
 import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
@@ -22,8 +21,7 @@ class BearerTokenClientInterceptor(private val oAuth2AccessTokenService: OAuth2A
     override fun intercept(request: HttpRequest, body: ByteArray, execution: ClientHttpRequestExecution): ClientHttpResponse {
         request.headers.setBearerAuth(genererAccessToken(request,
                                                          clientConfigurationProperties,
-                                                         oAuth2AccessTokenService,
-                                                         clientCredentialOrJwtBearer()))
+                                                         oAuth2AccessTokenService))
         return execution.execute(request, body)
     }
 }
@@ -38,6 +36,20 @@ class BearerTokenClientCredentialsClientInterceptor(private val oAuth2AccessToke
                                                          clientConfigurationProperties,
                                                          oAuth2AccessTokenService,
                                                          OAuth2GrantType.CLIENT_CREDENTIALS))
+        return execution.execute(request, body)
+    }
+}
+
+@Component
+class BearerTokenExchangeClientInterceptor(private val oAuth2AccessTokenService: OAuth2AccessTokenService,
+                                           private val clientConfigurationProperties: ClientConfigurationProperties) :
+        ClientHttpRequestInterceptor {
+
+    override fun intercept(request: HttpRequest, body: ByteArray, execution: ClientHttpRequestExecution): ClientHttpResponse {
+        request.headers.setBearerAuth(genererAccessToken(request,
+                                                         clientConfigurationProperties,
+                                                         oAuth2AccessTokenService,
+                                                         OAuth2GrantType.TOKEN_EXCHANGE))
         return execution.execute(request, body)
     }
 }
@@ -68,8 +80,7 @@ class BearerTokenWithSTSFallbackClientInterceptor(private val oAuth2AccessTokenS
         } else {
             request.headers.setBearerAuth(genererAccessToken(request,
                                                              clientConfigurationProperties,
-                                                             oAuth2AccessTokenService,
-                                                             clientCredentialOrJwtBearer()))
+                                                             oAuth2AccessTokenService))
         }
         return execution.execute(request, body)
     }
@@ -78,22 +89,45 @@ class BearerTokenWithSTSFallbackClientInterceptor(private val oAuth2AccessTokenS
 private fun genererAccessToken(request: HttpRequest,
                                clientConfigurationProperties: ClientConfigurationProperties,
                                oAuth2AccessTokenService: OAuth2AccessTokenService,
-                               grantType: OAuth2GrantType): String {
+                               grantType: OAuth2GrantType? = null): String {
     val clientProperties = clientPropertiesFor(request.uri,
                                                clientConfigurationProperties,
                                                grantType)
-    val response: OAuth2AccessTokenResponse = oAuth2AccessTokenService.getAccessToken(clientProperties)
-    return response.accessToken
+    return oAuth2AccessTokenService.getAccessToken(clientProperties).accessToken
 }
 
+/**
+ * Finds client property for grantType if specified.
+ *
+ * If the grantType isn't specified:
+ *  - Returns first client property, if there is only one
+ *  - Returns client property for client_credentials or jwt_bearer
+ */
 private fun clientPropertiesFor(uri: URI,
                                 clientConfigurationProperties: ClientConfigurationProperties,
                                 grantType: OAuth2GrantType?): ClientProperties {
-    return clientConfigurationProperties
-                   .registration
-                   .values
-                   .filter { uri.toString().startsWith(it.resourceUrl.toString()) }
-                   .firstOrNull { grantType == it.grantType }
+    val clientProperties = filterClientProperties(clientConfigurationProperties, uri)
+    return if (grantType == null) {
+        if (clientProperties.size == 1) {
+            clientProperties.first()
+        } else {
+            clientPropertiesForGrantType(clientProperties, clientCredentialOrJwtBearer(), uri)
+        }
+    } else {
+        clientPropertiesForGrantType(clientProperties, grantType, uri)
+    }
+}
+
+private fun filterClientProperties(clientConfigurationProperties: ClientConfigurationProperties,
+                                   uri: URI) = clientConfigurationProperties
+        .registration
+        .values
+        .filter { uri.toString().startsWith(it.resourceUrl.toString()) }
+
+private fun clientPropertiesForGrantType(values: List<ClientProperties>,
+                                         grantType: OAuth2GrantType,
+                                         uri: URI): ClientProperties {
+    return values.firstOrNull { grantType == it.grantType }
            ?: error("could not find oauth2 client config for uri=$uri and grant type=$grantType")
 }
 


### PR DESCRIPTION
…Properties hvis det kun finnes en. Då unngår vi att applikasjoner som bruker token-exchange slutter å virke når de oppdaterer felles

Denne virker nå som før denne endringen https://github.com/navikt/familie-felles/pull/327/files men i tillegg har explicite interceptors
 - BearerTokenClientCredentialsClientInterceptor
 - BearerTokenOnBehalfOfClientInterceptor
 - BearerTokenExchangeClientInterceptor