### PR TITLE
Utvid autorisasjonssjekk med en sjekk for request path

### DIFF
--- a/sikkerhet/src/main/java/no/nav/familie/sikkerhet/AcceptedClient.kt
+++ b/sikkerhet/src/main/java/no/nav/familie/sikkerhet/AcceptedClient.kt
@@ -1,0 +1,4 @@
+package no.nav.familie.sikkerhet
+
+class AcceptedClient(val clientId: String,
+                     val acceptedPaths: List<String> = listOf("/"))


### PR DESCRIPTION
Vi ønsker å begrense enkelte applikasjoner til å kun kalle ba-sak (f.eks.) med en gitt request path.

Eksempelvis vil vi at Bisys kun skal få lov til å kalle /api/bisys/*, men ikke andre paths.

I tillegg til client id, som vi sjekker for allerede, utvider vi her med en liste av tilgjengeliggjorte paths.

Dette vil medføre noen endringer hos ba-sak og oppdrag - spesielt i YAML-properties, så det er fint å ha en diskusjon på dette.

[Link til løsning for ba-sak her](https://github.com/navikt/familie-ba-sak/pull/1050).