### PR TITLE
Oppdaterer token-support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <bytebuddy.version>1.11.13</bytebuddy.version>
         <mockk.version>1.12.0</mockk.version>
         <micrometer.version>1.7.3</micrometer.version>
-        <nav.security.token.version>1.3.8</nav.security.token.version>
+        <nav.security.token.version>1.3.9</nav.security.token.version>
 
         <!--suppress UnresolvedMavenProperty  Ligger som secret i github-->
         <sonar.projectKey>${SONAR_PROJECTKEY}</sonar.projectKey>


### PR DESCRIPTION
pga breaking changes med shaded plugin i nimbus 9.x

Liten endring i token-support, men vi trenger den i ef-sak
https://github.com/navikt/token-support/releases/tag/1.3.9

Burde testes lokalt først før denne merges inn