### PR TITLE
Legger til felles KafkaErrorHandler, som ikke logger kafkamelding til…

### DIFF
--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>no.nav.familie.felles</groupId>
+        <artifactId>felles</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+    </parent>
+
+    <artifactId>kafka</artifactId>
+    <version>${revision}${sha1}${changelist}</version>
+    <name>Kafka - Util</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.mockk</groupId>
+            <artifactId>mockk</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>src/test/kotlin</testSourceDirectory>
+
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/kafka/src/main/kotlin/no/nav/familie/kafka/KafkaErrorHandler.kt
+++ b/kafka/src/main/kotlin/no/nav/familie/kafka/KafkaErrorHandler.kt
@@ -1,0 +1,79 @@
+package no.nav.familie.kafka
+
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.listener.ContainerStoppingErrorHandler
+import org.springframework.kafka.listener.MessageListenerContainer
+import org.springframework.scheduling.TaskScheduler
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+
+
+/**
+ * Hindrer spam i loggene ved gjentakende feil
+ */
+class KafkaErrorHandler(private val taskScheduler: TaskScheduler) : ContainerStoppingErrorHandler() {
+
+    private val logger: Logger = LoggerFactory.getLogger(javaClass)
+    private val secureLogger: Logger = LoggerFactory.getLogger("secureLogger")
+
+    private val counter = AtomicInteger(0)
+    private val lastError = AtomicLong(0)
+
+    override fun handle(e: Exception,
+                        records: List<ConsumerRecord<*, *>>,
+                        consumer: Consumer<*, *>,
+                        container: MessageListenerContainer
+    ) {
+        if (records.isEmpty()) {
+            logger.error("Feil ved konsumering av melding. Ingen records. ${consumer.subscription()}", e)
+            scheduleRestart(e, records, consumer, container, "Ukjent topic")
+        } else {
+            records.first().run {
+                logger.error(
+                        "Feil ved konsumering av melding fra ${this.topic()}. id ${this.key()}, " +
+                        "offset: ${this.offset()}, partition: ${this.partition()}"
+                )
+                secureLogger.error("${this.topic()} - Problemer med prosessering av $records", e)
+                scheduleRestart(e, records, consumer, container, this.topic())
+            }
+        }
+    }
+
+    private fun scheduleRestart(e: Exception,
+                                records: List<ConsumerRecord<*, *>>,
+                                consumer: Consumer<*, *>,
+                                container: MessageListenerContainer,
+                                topic: String) {
+        val now = System.currentTimeMillis()
+        if (now - lastError.getAndSet(now) > COUNTER_RESET_TIME) {
+            counter.set(0)
+        }
+        val numErrors = counter.incrementAndGet()
+        val stopTime = if (numErrors > SLOW_ERROR_COUNT) LONG else SHORT * numErrors
+        taskScheduler.schedule( {
+                                    try {
+                                        logger.warn("Starter kafka container for {}", topic)
+                                        container.start()
+                                    } catch (exception: Exception) {
+                                        logger.error("Feil oppstod ved venting og oppstart av kafka container", exception)
+                                    }
+                                },
+                                Instant.ofEpochMilli(now + stopTime ))
+        logger.warn("Stopper kafka container for {} i {}", topic, Duration.ofMillis(stopTime))
+        super.handle(Exception("Sjekk securelogs for mer info - ${e::class.java.simpleName}"), records, consumer, container)
+    }
+
+    companion object {
+        private val LONG = Duration.ofHours(3).toMillis()
+        private val SHORT = Duration.ofSeconds(20).toMillis()
+        private const val SLOW_ERROR_COUNT = 10
+        private val COUNTER_RESET_TIME =
+                SHORT * SLOW_ERROR_COUNT * 2
+    }
+
+}

--- a/kafka/src/test/kotlin/no/nav/familie/kafka/KafkaErrorHandlerTest.kt
+++ b/kafka/src/test/kotlin/no/nav/familie/kafka/KafkaErrorHandlerTest.kt
@@ -1,0 +1,51 @@
+package no.nav.familie.kafka
+
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.impl.annotations.MockK
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.kafka.listener.MessageListenerContainer
+import org.springframework.scheduling.TaskScheduler
+import org.springframework.scheduling.concurrent.DefaultManagedTaskScheduler
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class KafkaErrorHandlerTest {
+
+    @MockK(relaxed = true)
+    lateinit var container: MessageListenerContainer;
+
+    @MockK(relaxed = true)
+    lateinit var consumer: Consumer<*, *>
+
+    private val taskScheduler: TaskScheduler = DefaultManagedTaskScheduler()
+
+    private val errorHandler: KafkaErrorHandler = KafkaErrorHandler(taskScheduler)
+
+    @BeforeEach
+    internal fun setUp() {
+        MockKAnnotations.init(this)
+        clearAllMocks()
+    }
+
+    @Test
+    fun `skal stoppe container hvis man mottar feil med en tom liste med records`() {
+        assertThatThrownBy { errorHandler.handle(RuntimeException("Feil i test"), emptyList(), consumer, container) }
+                .hasMessageNotContaining("Feil i test")
+                .hasMessageContaining("Sjekk securelogs for mer info")
+                .hasCauseExactlyInstanceOf(Exception::class.java)
+    }
+
+    @Test
+    fun `skal stoppe container hvis man mottar feil med en liste med records`() {
+        val consumerRecord = ConsumerRecord("topic", 1, 1, 1, "record")
+        assertThatThrownBy { errorHandler.handle(RuntimeException("Feil i test"), listOf(consumerRecord), consumer, container) }
+                .hasMessageNotContaining("Feil i test")
+                .hasMessageContaining("Sjekk securelogs for mer info")
+                .hasCauseExactlyInstanceOf(Exception::class.java)
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <module>leader</module>
         <module>prosessering</module>
         <module>util</module>
+        <module>kafka</module>
     </modules>
 
     <dependencyManagement>
@@ -130,6 +131,11 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-actuator</artifactId>
                 <version>${spring.boot.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.kafka</groupId>
+                <artifactId>spring-kafka</artifactId>
+                <version>${spring.boot.version}.RELEASE</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>


### PR DESCRIPTION
… vanlig logg

Et problem men den som brukes og kopieres i de andre appene er att man bruker 
`super.handle(e, records, consumer, container)`

Denne kaller super som sen kaster exception som blir håndtert i en annen klasse, som logger kafka-melding-body til vanlig logg.

Jeg ønsker ikke att denne har `@Component`, men att den kan tas i bruk i en `@Configuration` med `@Bean`

Diskusjon (se forskjell mot https://github.com/navikt/familie-ba-sak/blob/18111914aba92d39a07f3ef7b24b5a0a3a25e2af/src/main/kotlin/no/nav/familie/ba/sak/config/KafkaAivenErrorHandler.kt): 

- Trenger vi `Thread.sleep`? 
- `executor.schedule` vs `executor.execute`