### PR TITLE
Fjernet @Component fra ECBRestClientInterceptor

### DIFF
--- a/http-client/src/main/java/no/nav/familie/http/ecb/config/ECBRestClientConfig.kt
+++ b/http-client/src/main/java/no/nav/familie/http/ecb/config/ECBRestClientConfig.kt
@@ -8,14 +8,12 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
 import org.springframework.web.client.RestOperations
 
 @Suppress("SpringFacetCodeInspection")
 @Configuration
-@Import(ECBRestClientInterceptor::class)
 class ECBRestClientConfig {
 
     @Bean("ecbMapper")
@@ -28,13 +26,13 @@ class ECBRestClientConfig {
     }
 
     @Bean("ecbRestTemplate")
-    fun xmlRestTemplate(ecbRestClientInterceptor: ECBRestClientInterceptor, @Qualifier("ecbMapper") xmlMapper: XmlMapper): RestOperations {
+    fun xmlRestTemplate(@Qualifier("ecbMapper") xmlMapper: XmlMapper): RestOperations {
         val converter = MappingJackson2HttpMessageConverter(xmlMapper).apply {
             supportedMediaTypes = listOf(MediaType.parseMediaType("application/vnd.sdmx.genericdata+xml;version=2.1"))
         }
         return RestTemplateBuilder()
             .additionalMessageConverters(converter)
-            .additionalInterceptors(ecbRestClientInterceptor)
+            .additionalInterceptors(ECBRestClientInterceptor())
             .build()
     }
 }

--- a/http-client/src/main/java/no/nav/familie/http/ecb/interceptor/ECBRestClientInterceptor.kt
+++ b/http-client/src/main/java/no/nav/familie/http/ecb/interceptor/ECBRestClientInterceptor.kt
@@ -5,9 +5,7 @@ import org.springframework.http.MediaType
 import org.springframework.http.client.ClientHttpRequestExecution
 import org.springframework.http.client.ClientHttpRequestInterceptor
 import org.springframework.http.client.ClientHttpResponse
-import org.springframework.stereotype.Component
 
-@Component
 class ECBRestClientInterceptor : ClientHttpRequestInterceptor {
     override fun intercept(request: HttpRequest, body: ByteArray, execution: ClientHttpRequestExecution): ClientHttpResponse {
         request.headers.accept = listOf(MediaType.APPLICATION_XML)

--- a/http-client/src/test/java/no/nav/familie/http/ecb/ECBClientTest.kt
+++ b/http-client/src/test/java/no/nav/familie/http/ecb/ECBClientTest.kt
@@ -15,7 +15,6 @@ import no.nav.familie.http.ecb.domene.ECBExchangeRatesForCurrency
 import no.nav.familie.http.ecb.domene.exchangeRateForCurrency
 import no.nav.familie.http.ecb.exception.ECBClientException
 import no.nav.familie.http.ecb.exception.ECBTransformationException
-import no.nav.familie.http.ecb.interceptor.ECBRestClientInterceptor
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -53,7 +52,7 @@ class ECBClientTest {
 
             val config = ECBRestClientConfig()
             xmlMapper = config.xmlMapper()
-            val restTemplate = config.xmlRestTemplate(ECBRestClientInterceptor(), xmlMapper)
+            val restTemplate = config.xmlRestTemplate(xmlMapper)
             ecbRestClient = ECBRestClient(restTemplate, URI.create("http://localhost:${wireMockServer.port()}/").toString())
         }
 


### PR DESCRIPTION
`@Component` på ECBRestClientInterceptor skapte problemer for apper som bruker component scan på hele `familie-felles`. Har derfor fjernet `@Component` og initialiserer ECBRestClientInterceptor direkte inne i RestTemplate configen for ECB.