### PR TITLE
Skal plukke opp requestId fra nginx eller andre applikasjoner, og set…

### DIFF
--- a/http-client/src/main/java/no/nav/familie/http/interceptor/MdcValuesPropagatingClientInterceptor.kt
+++ b/http-client/src/main/java/no/nav/familie/http/interceptor/MdcValuesPropagatingClientInterceptor.kt
@@ -15,7 +15,7 @@ class MdcValuesPropagatingClientInterceptor : ClientHttpRequestInterceptor {
 
     override fun intercept(request: HttpRequest, body: ByteArray, execution: ClientHttpRequestExecution): ClientHttpResponse {
         val callId = MDC.get(MDCConstants.MDC_CALL_ID) ?: IdUtils.generateId()
-        val requestId = MDC.get(MDCConstants.MDC_REQUEST_ID) ?: IdUtils.generateId()
+        val requestId = MDC.get(MDCConstants.MDC_REQUEST_ID) ?: callId
         request.headers.add(NavHttpHeaders.NAV_CALL_ID.asString(), callId)
         request.headers.add(NavHttpHeaders.NGNINX__REQUEST_ID.asString(), requestId)
 

--- a/http-client/src/main/java/no/nav/familie/http/interceptor/MdcValuesPropagatingClientInterceptor.kt
+++ b/http-client/src/main/java/no/nav/familie/http/interceptor/MdcValuesPropagatingClientInterceptor.kt
@@ -17,7 +17,7 @@ class MdcValuesPropagatingClientInterceptor : ClientHttpRequestInterceptor {
         val callId = MDC.get(MDCConstants.MDC_CALL_ID) ?: IdUtils.generateId()
         val requestId = MDC.get(MDCConstants.MDC_REQUEST_ID) ?: callId
         request.headers.add(NavHttpHeaders.NAV_CALL_ID.asString(), callId)
-        request.headers.add(NavHttpHeaders.NGNINX__REQUEST_ID.asString(), requestId)
+        request.headers.add(NavHttpHeaders.NGNINX_REQUEST_ID.asString(), requestId)
 
         return execution.execute(request, body)
     }

--- a/http-client/src/main/java/no/nav/familie/http/interceptor/MdcValuesPropagatingClientInterceptor.kt
+++ b/http-client/src/main/java/no/nav/familie/http/interceptor/MdcValuesPropagatingClientInterceptor.kt
@@ -15,7 +15,9 @@ class MdcValuesPropagatingClientInterceptor : ClientHttpRequestInterceptor {
 
     override fun intercept(request: HttpRequest, body: ByteArray, execution: ClientHttpRequestExecution): ClientHttpResponse {
         val callId = MDC.get(MDCConstants.MDC_CALL_ID) ?: IdUtils.generateId()
+        val requestId = MDC.get(MDCConstants.MDC_REQUEST_ID) ?: IdUtils.generateId()
         request.headers.add(NavHttpHeaders.NAV_CALL_ID.asString(), callId)
+        request.headers.add(NavHttpHeaders.NGNINX__REQUEST_ID.asString(), requestId)
 
         return execution.execute(request, body)
     }

--- a/log/src/main/java/no/nav/familie/log/NavHttpHeaders.kt
+++ b/log/src/main/java/no/nav/familie/log/NavHttpHeaders.kt
@@ -3,7 +3,7 @@ package no.nav.familie.log
 enum class NavHttpHeaders(private val header: String) {
     NAV_PERSONIDENT("Nav-Personident"),
     NAV_CALL_ID("Nav-Call-Id"),
-    NGNINX__REQUEST_ID("X_Request_Id"),
+    NGNINX_REQUEST_ID("X-Request-Id"),
     NAV_CONSUMER_ID("Nav-Consumer-Id"),
     NAV_USER_ID("Nav-User-Id");
 

--- a/log/src/main/java/no/nav/familie/log/NavHttpHeaders.kt
+++ b/log/src/main/java/no/nav/familie/log/NavHttpHeaders.kt
@@ -3,6 +3,7 @@ package no.nav.familie.log
 enum class NavHttpHeaders(private val header: String) {
     NAV_PERSONIDENT("Nav-Personident"),
     NAV_CALL_ID("Nav-Call-Id"),
+    NGNINX__REQUEST_ID("X_Request_Id"),
     NAV_CONSUMER_ID("Nav-Consumer-Id"),
     NAV_USER_ID("Nav-User-Id");
 

--- a/log/src/main/java/no/nav/familie/log/mdc/MDCConstants.kt
+++ b/log/src/main/java/no/nav/familie/log/mdc/MDCConstants.kt
@@ -4,9 +4,5 @@ object MDCConstants {
     const val MDC_USER_ID = "userId"
     const val MDC_CONSUMER_ID = "consumerId"
     const val MDC_CALL_ID = "callId"
-
-    /**
-     * trengs for å spore kall som går via nginx/controller - den bruker underscore
-     **/
-    const val MDC_REQUEST_ID = "request_Id"
+    const val MDC_REQUEST_ID = "requestId"
 }

--- a/log/src/main/java/no/nav/familie/log/mdc/MDCConstants.kt
+++ b/log/src/main/java/no/nav/familie/log/mdc/MDCConstants.kt
@@ -4,5 +4,9 @@ object MDCConstants {
     const val MDC_USER_ID = "userId"
     const val MDC_CONSUMER_ID = "consumerId"
     const val MDC_CALL_ID = "callId"
-    const val MDC_REQUEST_ID = "requestId"
+
+    /**
+     * trengs for å spore kall som går via nginx/controller - den bruker underscore
+     **/
+    const val MDC_REQUEST_ID = "request_Id"
 }


### PR DESCRIPTION
…te vår requestId til det samme. Ellers genereres en ny.

Det er diskutert på slack at vi kanskje kan gjøre det litt mer avansert mtp callId, men det kan være risiko mtp å "miste" callId og requestId for applikasjoner som ikke har oppdatert til siste versjon av felles. I tillegg har vi ikke helt kontroll på requestId som sådan. Nå er det iallefall mulig å spore opp kallene som går via controlleren - enten om den setter request_id først, eller plukker opp vår request_id. 

Litt usikker på om vi trenger `X_request_id` i den lista vår, eller om det er noe kibana-greier som putter på `x` foran?