### PR TITLE
Flyttar over QueryUtil-klassa frå familie-kontrakter

### DIFF
--- a/http-client/src/main/java/no/nav/familie/http/util/QueryUtil.kt
+++ b/http-client/src/main/java/no/nav/familie/http/util/QueryUtil.kt
@@ -1,0 +1,22 @@
+package no.nav.familie.http.util
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.familie.kontrakter.felles.objectMapper
+import org.springframework.util.LinkedMultiValueMap
+
+fun toQueryParams(any: Any): LinkedMultiValueMap<String, String> {
+    val writeValueAsString = objectMapper.writeValueAsString(any)
+    val readValue: LinkedHashMap<String, Any?> = objectMapper.readValue(writeValueAsString)
+    val queryParams = LinkedMultiValueMap<String, String>()
+    readValue.filterNot { it.value == null }
+        .filterNot { it.value is List<*> && (it.value as List<*>).isEmpty() }
+        .forEach {
+            if (it.value is List<*>) {
+                val liste = (it.value as List<*>).map { elem -> elem.toString() }
+                queryParams.addAll(it.key, liste)
+            } else {
+                queryParams.add(it.key, it.value.toString())
+            }
+        }
+    return queryParams
+}

--- a/http-client/src/test/java/no/nav/familie/http/util/QueryUtilKtTest.kt
+++ b/http-client/src/test/java/no/nav/familie/http/util/QueryUtilKtTest.kt
@@ -1,0 +1,29 @@
+package no.nav.familie.http.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+import org.springframework.util.LinkedMultiValueMap
+
+internal class QueryUtilKtTest {
+
+    @Test
+    fun `toQueryParams ivaretar lister som lister`() {
+        val queryParams: LinkedMultiValueMap<String, String> = toQueryParams(Testdata())
+
+        assertEquals(listOf("1", "2", "3", "4", "5"), queryParams["list"])
+    }
+
+    @Test
+    fun `toQueryParams filtrerer vekk tomme lister`() {
+        val queryParams: LinkedMultiValueMap<String, String> = toQueryParams(Testdata(list = listOf()))
+
+        assertFalse { queryParams.containsKey("list") }
+    }
+
+    data class Testdata(
+        val int: Int = 5,
+        val string: String = "Fem",
+        val list: List<Int> = listOf(1, 2, 3, 4, 5)
+    )
+}


### PR DESCRIPTION
Eg trur vi eigentleg kunne ha skrive om denne frå å bruke MultiValueMap, og med det fjerne Spring-avhengnaden her, men det er litt risiko i det, og når klassa ligg her gjer det uansett ikkje så mykje, sia vi uansett har avhengnaden her.

Heng saman med https://github.com/navikt/familie-kontrakter/pull/684