### PR TITLE
webClient lesRessurs skal skal lese body som utf8 og ikke default som…

### DIFF
--- a/web-client/src/main/java/no/nav/familie/webflux/client/AbstractWebClient.kt
+++ b/web-client/src/main/java/no/nav/familie/webflux/client/AbstractWebClient.kt
@@ -14,6 +14,7 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import org.springframework.web.reactive.function.client.bodyToMono
 import reactor.core.publisher.Mono
 import java.net.URI
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.TimeUnit
 
 /**
@@ -110,7 +111,7 @@ abstract class AbstractWebClient(
 
     private fun lesRessurs(e: WebClientResponseException): Ressurs<Any>? = try {
         if (e.responseBodyAsString.contains("status")) {
-            objectMapper.readValue<Ressurs<Any>>(e.responseBodyAsString)
+            objectMapper.readValue<Ressurs<Any>>(e.getResponseBodyAsString(StandardCharsets.UTF_8))
         } else {
             null
         }

--- a/web-client/src/test/java/no/nav/familie/webflux/client/AbstractWebClientTest.kt
+++ b/web-client/src/test/java/no/nav/familie/webflux/client/AbstractWebClientTest.kt
@@ -40,11 +40,10 @@ internal class AbstractWebClientTest {
     internal fun `happy case`() {
         val responseRessurs = Ressurs.success("Ok Åæø")
         val body = objectMapper.writeValueAsString(responseRessurs)
-        wireMockServer.stubFor(
-            WireMock.get(WireMock.anyUrl())
-                .willReturn(WireMock.aResponse().withStatus(200).withBody(body))
-        )
+        wireMockServer.stubFor(WireMock.get(WireMock.anyUrl()).willReturn(WireMock.okJson(body)))
+
         val ressurs = client.test()
+
         assertThat(ressurs).isEqualTo(responseRessurs)
     }
 

--- a/web-client/src/test/java/no/nav/familie/webflux/client/AbstractWebClientTest.kt
+++ b/web-client/src/test/java/no/nav/familie/webflux/client/AbstractWebClientTest.kt
@@ -21,8 +21,8 @@ internal class AbstractWebClientTest {
 
     class TestClient(val uri: URI) : AbstractWebClient(WebClient.create(), "") {
 
-        fun test() {
-            getForEntity<Ressurs<Any>>(uri)
+        fun test(): Ressurs<String> {
+            return getForEntity(uri)
         }
     }
 
@@ -37,8 +37,20 @@ internal class AbstractWebClientTest {
     }
 
     @Test
+    internal fun `happy case`() {
+        val responseRessurs = Ressurs.success("Ok Åæø")
+        val body = objectMapper.writeValueAsString(responseRessurs)
+        wireMockServer.stubFor(
+            WireMock.get(WireMock.anyUrl())
+                .willReturn(WireMock.aResponse().withStatus(200).withBody(body))
+        )
+        val ressurs = client.test()
+        assertThat(ressurs).isEqualTo(responseRessurs)
+    }
+
+    @Test
     internal fun `feil med ressurs kaster RessursException`() {
-        val ressurs = Ressurs.failure<Any>("Feilet")
+        val ressurs = Ressurs.failure<Any>("FeiletÅæø")
         val body = objectMapper.writeValueAsString(ressurs)
         wireMockServer.stubFor(
             WireMock.get(WireMock.anyUrl())


### PR DESCRIPTION
… er ISO_8859_1 i WebClientResponseException

Hvis ikke så får vi litt rare tegn for dette. Json sendes vanligtvis som utf8/17, men charset settes ikke av noen grunn