### PR TITLE
Felles Unleash pakke for kobling mot Unleash Next

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <module>util</module>
         <module>kafka</module>
         <module>valutakurs-klient</module>
+        <module>unleash</module>
     </modules>
 
     <dependencyManagement>

--- a/unleash/pom.xml
+++ b/unleash/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>no.nav.familie.felles</groupId>
+        <artifactId>felles</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+    </parent>
+
+    <artifactId>unleash</artifactId>
+    <version>${revision}${sha1}${changelist}</version>
+    <name>Felles - Unleash</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.getunleash</groupId>
+            <artifactId>unleash-client-java</artifactId>
+            <version>8.2.1</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>src/test/kotlin</testSourceDirectory>
+
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>testCompile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/unleash/src/main/kotlin/no/nav/familie/unleash/DefaultUnleashService.kt
+++ b/unleash/src/main/kotlin/no/nav/familie/unleash/DefaultUnleashService.kt
@@ -5,7 +5,7 @@ import io.getunleash.UnleashContext
 import io.getunleash.UnleashContextProvider
 import io.getunleash.util.UnleashConfig
 
-class UnleashNextFeatureToggleService(
+class DefaultUnleashService(
     val apiUrl: String,
     val apiToken: String,
     val appName: String

--- a/unleash/src/main/kotlin/no/nav/familie/unleash/UnleashConfig.kt
+++ b/unleash/src/main/kotlin/no/nav/familie/unleash/UnleashConfig.kt
@@ -1,0 +1,57 @@
+package no.nav.familie.unleash
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.stereotype.Component
+
+@EnableConfigurationProperties(UnleashProperties::class)
+@Component
+class UnleashConfig(
+    private val featureToggleProperties: UnleashProperties,
+    @Value("\${UNLEASH_SERVER_API_URL}") val apiUrl: String,
+    @Value("\${UNLEASH_SERVER_API_TOKEN}") val apiToken: String,
+    @Value("\${NAIS_APP_NAME}") val appName: String
+) {
+
+    @Bean("unleashNext")
+    fun unleashNext(): UnleashService =
+        if (featureToggleProperties.enabled) {
+            UnleashNextFeatureToggleService(apiUrl = apiUrl, apiToken = apiToken, appName = appName)
+        } else {
+            logger.warn(
+                "Funksjonsbryter-funksjonalitet er skrudd AV. " +
+                    "Gir standardoppførsel for alle funksjonsbrytere, dvs 'false'"
+            )
+            lagDummyFeatureToggleService()
+        }
+
+    private fun lagDummyFeatureToggleService(): UnleashService {
+        return object : UnleashService {
+            override fun isEnabled(toggleId: String, defaultValue: Boolean): Boolean {
+                return System.getenv(toggleId).run { toBoolean() } || defaultValue
+            }
+        }
+    }
+
+    companion object {
+
+        private val logger = LoggerFactory.getLogger(UnleashProperties::class.java)
+    }
+}
+
+@ConfigurationProperties("unleash")
+class UnleashProperties(
+    val enabled: Boolean = true
+)
+
+interface UnleashService {
+
+    fun isEnabled(toggleId: String): Boolean {
+        return isEnabled(toggleId, false)
+    }
+
+    fun isEnabled(toggleId: String, defaultValue: Boolean): Boolean
+}

--- a/unleash/src/main/kotlin/no/nav/familie/unleash/UnleashNextFeatureToggleService.kt
+++ b/unleash/src/main/kotlin/no/nav/familie/unleash/UnleashNextFeatureToggleService.kt
@@ -1,0 +1,38 @@
+package no.nav.familie.unleash
+
+import io.getunleash.DefaultUnleash
+import io.getunleash.UnleashContext
+import io.getunleash.UnleashContextProvider
+import io.getunleash.util.UnleashConfig
+
+class UnleashNextFeatureToggleService(
+    val apiUrl: String,
+    val apiToken: String,
+    val appName: String
+) : UnleashService {
+
+    private val defaultUnleash: DefaultUnleash
+
+    init {
+
+        defaultUnleash = DefaultUnleash(
+            UnleashConfig.builder()
+                .appName(appName)
+                .unleashAPI("$apiUrl/api")
+                .apiKey(apiToken)
+                .unleashContextProvider(lagUnleashContextProvider()).build()
+        )
+    }
+
+    private fun lagUnleashContextProvider(): UnleashContextProvider {
+        return UnleashContextProvider {
+            UnleashContext.builder()
+                .appName(appName)
+                .build()
+        }
+    }
+
+    override fun isEnabled(toggleId: String, defaultValue: Boolean): Boolean {
+        return defaultUnleash.isEnabled(toggleId, defaultValue)
+    }
+}


### PR DESCRIPTION
Lagt til pakken `unleash`. Denne gir oss mulighet til å ha en felles implementasjon mot Unleash som kan brukes på tvers i team-familie. 

I hver enkelt applikasjon man skal bruke feature-toggles, blir man nødt til å legge inn `@ComponentScan("no.nav.familie.unleash", ...)` i App-configen. Deretter kan man ta ibruk servicen `UnleashService` som tilbyr `isEnabled()`-metoden.

Hvor vidt man går mot unleash eller ikke kan styres med app-properties:
```
// Default
unleash:
   enabled: true 
   
// Dersom man ønsker at alle toggles skal gi isEnabled = false eller default verdi der det er definert
unleash:
   enabled: false 
```

Pakka krever følgende miljøvariabler:
* UNLEASH_SERVER_API_URL (se [Unleash-doc](https://docs.nais.io/addons/unleash-next/))
* UNLEASH_SERVER_API_TOKEN (se [Unleash-doc](https://docs.nais.io/addons/unleash-next/))
* NAIS_APP_NAME