### PR TITLE
Fix RequestTimeFilter - metode må være open for å kunne overrides

### DIFF
--- a/log/src/main/java/no/nav/familie/log/filter/RequestTimeFilter.kt
+++ b/log/src/main/java/no/nav/familie/log/filter/RequestTimeFilter.kt
@@ -45,8 +45,7 @@ open class RequestTimeFilter : Filter {
         }
     }
 
-    @Suppress("MemberVisibilityCanBePrivate") // kan overrides hvis det ønskes
-    fun shouldNotFilter(uri: String): Boolean {
+    open fun shouldNotFilter(uri: String): Boolean {
         return uri.contains("/internal") || uri == "/api/ping"
     }
 


### PR DESCRIPTION
Manglet open modifier for at overriding tillates. Bruker denne i dokgen hvor det er behov for å override ettersom nais-endepunktene ikke ligger under /internal. 