### PR TITLE
Oppgradering til token-support 4.1.3.

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -43,15 +43,17 @@ jobs:
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: github.base_ref == 'main' && github.event.pull_request.merged == true
         run: |
           export GIT_COMMIT_HASH=$(git log -n 1 --pretty=format:'%h')
           export GIT_COMMIT_DATE=$(git log -1 --pretty='%ad' --date=format:'%Y%m%d%H%M%S')
-          export VERSION=2.${GIT_COMMIT_DATE}_${GIT_COMMIT_HASH}_token-support-4
+          export VERSION=3.${GIT_COMMIT_DATE}_${GIT_COMMIT_HASH}
           echo "Setting version $VERSION"
           mvn --settings .m2/maven-settings.xml versions:set -DnewVersion="$VERSION"
           mvn --settings .m2/maven-settings.xml versions:commit
 
       - name: Deploy to Github Package
+        if: github.base_ref == 'main' && github.event.pull_request.merged == true
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -43,17 +43,15 @@ jobs:
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: github.base_ref == 'main' && github.event.pull_request.merged == true
         run: |
           export GIT_COMMIT_HASH=$(git log -n 1 --pretty=format:'%h')
           export GIT_COMMIT_DATE=$(git log -1 --pretty='%ad' --date=format:'%Y%m%d%H%M%S')
-          export VERSION=2.${GIT_COMMIT_DATE}_${GIT_COMMIT_HASH}
+          export VERSION=2.${GIT_COMMIT_DATE}_${GIT_COMMIT_HASH}_token-support-4
           echo "Setting version $VERSION"
           mvn --settings .m2/maven-settings.xml versions:set -DnewVersion="$VERSION"
           mvn --settings .m2/maven-settings.xml versions:commit
 
       - name: Deploy to Github Package
-        if: github.base_ref == 'main' && github.event.pull_request.merged == true
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/http-client/src/main/java/no/nav/familie/http/client/RetryOAuth2HttpClient.kt
+++ b/http-client/src/main/java/no/nav/familie/http/client/RetryOAuth2HttpClient.kt
@@ -4,16 +4,16 @@ import no.nav.security.token.support.client.core.http.OAuth2HttpRequest
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenResponse
 import no.nav.security.token.support.client.spring.oauth2.DefaultOAuth2HttpClient
 import org.slf4j.LoggerFactory
-import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.core.NestedExceptionUtils
 import org.springframework.web.client.HttpServerErrorException
+import org.springframework.web.client.RestClient
 import java.net.SocketException
 import java.net.SocketTimeoutException
 
 class RetryOAuth2HttpClient(
-    restTemplateBuilder: RestTemplateBuilder,
+    restClient: RestClient,
     private val maxRetries: Int = 2,
-) : DefaultOAuth2HttpClient(restTemplateBuilder) {
+) : DefaultOAuth2HttpClient(restClient) {
     private val logger = LoggerFactory.getLogger(javaClass)
     private val secureLogger = LoggerFactory.getLogger("secureLogger")
 
@@ -25,7 +25,7 @@ class RetryOAuth2HttpClient(
             HttpServerErrorException.BadGateway::class,
         )
 
-    override fun post(oAuth2HttpRequest: OAuth2HttpRequest): OAuth2AccessTokenResponse? {
+    override fun post(oAuth2HttpRequest: OAuth2HttpRequest): OAuth2AccessTokenResponse {
         var retries = 0
 
         while (true) {

--- a/http-client/src/test/java/no/nav/familie/http/client/RetryOAuth2HttpClientTest.kt
+++ b/http-client/src/test/java/no/nav/familie/http/client/RetryOAuth2HttpClientTest.kt
@@ -12,18 +12,25 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.boot.web.client.ClientHttpRequestFactories
+import org.springframework.boot.web.client.ClientHttpRequestFactorySettings
+import org.springframework.web.client.RestClient
 import java.net.URI
 import java.time.Duration
 import java.time.temporal.ChronoUnit
 
 internal class RetryOAuth2HttpClientTest {
-    private val restTemplateBuilder =
-        RestTemplateBuilder()
-            .setConnectTimeout(Duration.of(1, ChronoUnit.SECONDS))
-            .setReadTimeout(Duration.of(1, ChronoUnit.SECONDS))
+    val clientHttpRequestFactorySettings =
+        ClientHttpRequestFactorySettings.DEFAULTS
+            .withConnectTimeout(Duration.of(1, ChronoUnit.SECONDS))
+            .withReadTimeout(Duration.of(1, ChronoUnit.SECONDS))
 
-    private val client = RetryOAuth2HttpClient(restTemplateBuilder)
+    val requestFactory = ClientHttpRequestFactories.get(clientHttpRequestFactorySettings)
+    val restClient =
+        RestClient.builder()
+            .requestFactory(requestFactory)
+            .build()
+    val client = RetryOAuth2HttpClient(restClient)
 
     @BeforeEach
     internal fun setUp() {
@@ -39,21 +46,21 @@ internal class RetryOAuth2HttpClientTest {
 
     @Test
     internal fun `404 - skal kun kalle en gang`() {
-        stub(WireMock.serverError().withStatus(404))
+        stub(WireMock.notFound())
         post()
         wireMockServer.verify(1, RequestPatternBuilder.allRequests())
     }
 
     @Test
     internal fun `503 - skal prøve på nytt`() {
-        stub(WireMock.aResponse().withStatus(503))
+        stub(WireMock.serviceUnavailable())
         post()
         wireMockServer.verify(2, RequestPatternBuilder.allRequests())
     }
 
     @Test
     internal fun `502 - skal prøve på nytt`() {
-        stub(WireMock.serverError().withStatus(502))
+        stub(WireMock.serverError().withStatus(502).withFault(Fault.CONNECTION_RESET_BY_PEER))
         post()
         wireMockServer.verify(3, RequestPatternBuilder.allRequests())
     }
@@ -82,8 +89,7 @@ internal class RetryOAuth2HttpClientTest {
     private fun post(): Exception? {
         return try {
             client.post(
-                OAuth2HttpRequest.builder()
-                    .tokenEndpointUrl(URI.create(wireMockServer.baseUrl()))
+                OAuth2HttpRequest.builder(URI.create(wireMockServer.baseUrl()))
                     .oAuth2HttpHeaders(OAuth2HttpHeaders.builder().build())
                     .build(),
             )

--- a/http-client/src/test/java/no/nav/familie/http/interceptor/BearerTokenClientCredentialsClientInterceptorTest.kt
+++ b/http-client/src/test/java/no/nav/familie/http/interceptor/BearerTokenClientCredentialsClientInterceptorTest.kt
@@ -34,7 +34,7 @@ internal class BearerTokenClientCredentialsClientInterceptorTest {
 
         bearerTokenClientInterceptor.intercept(req, ByteArray(0), execution)
 
-        verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration["1"]) }
+        verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration.get("1")!!) }
     }
 
     @Test
@@ -45,7 +45,7 @@ internal class BearerTokenClientCredentialsClientInterceptorTest {
         assertThat(catchThrowable { bearerTokenClientInterceptor.intercept(req, ByteArray(0), execution) })
             .hasMessage(
                 "could not find oauth2 client config for " +
-                    "uri=http://jwtResource.no and grant type=OAuth2GrantType[value=client_credentials]",
+                    "uri=http://jwtResource.no and grant type=client_credentials",
             )
     }
 }

--- a/http-client/src/test/java/no/nav/familie/http/interceptor/BearerTokenClientInterceptorTest.kt
+++ b/http-client/src/test/java/no/nav/familie/http/interceptor/BearerTokenClientInterceptorTest.kt
@@ -43,7 +43,7 @@ class BearerTokenClientInterceptorTest {
 
         bearerTokenClientInterceptor.intercept(req, ByteArray(0), execution)
 
-        verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration["1"]) }
+        verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration["1"]!!) }
     }
 
     @Test
@@ -56,7 +56,7 @@ class BearerTokenClientInterceptorTest {
 
         bearerTokenClientInterceptor.intercept(req, ByteArray(0), execution)
 
-        verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration["2"]) }
+        verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration["2"]!!) }
     }
 
     fun mockBrukerContext(preferredUsername: String) {

--- a/http-client/src/test/java/no/nav/familie/http/interceptor/BearerTokenOnBehalfOfClientInterceptorTest.kt
+++ b/http-client/src/test/java/no/nav/familie/http/interceptor/BearerTokenOnBehalfOfClientInterceptorTest.kt
@@ -33,7 +33,7 @@ internal class BearerTokenOnBehalfOfClientInterceptorTest {
 
         bearerTokenClientInterceptor.intercept(req, ByteArray(0), execution)
 
-        verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration["2"]) }
+        verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration["2"]!!) }
     }
 
     @Test
@@ -44,7 +44,7 @@ internal class BearerTokenOnBehalfOfClientInterceptorTest {
         Assertions.assertThat(Assertions.catchThrowable { bearerTokenClientInterceptor.intercept(req, ByteArray(0), execution) })
             .hasMessage(
                 "could not find oauth2 client config for " +
-                    "uri=http://clientResource.no and grant type=OAuth2GrantType[value=urn:ietf:params:oauth:grant-type:jwt-bearer]",
+                    "uri=http://clientResource.no and grant type=urn:ietf:params:oauth:grant-type:jwt-bearer",
             )
     }
 }

--- a/log/src/main/java/no/nav/familie/log/filter/RequestTimeFilter.kt
+++ b/log/src/main/java/no/nav/familie/log/filter/RequestTimeFilter.kt
@@ -44,7 +44,7 @@ open class RequestTimeFilter : Filter {
             }
         }
     }
-    
+
     open fun shouldNotFilter(uri: String): Boolean {
         return uri.contains("/internal") || uri == "/api/ping"
     }

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <kotest.version>5.8.0</kotest.version>
         <kotlin.version>1.9.22</kotlin.version>
         <mockk.version>1.13.9</mockk.version>
-        <nav.security.token.version>3.2.0</nav.security.token.version>
+        <nav.security.token.version>4.1.3</nav.security.token.version>
 
         <!--suppress UnresolvedMavenProperty  Ligger som secret i github-->
         <sonar.projectKey>${SONAR_PROJECTKEY}</sonar.projectKey>
@@ -88,6 +88,11 @@
                 <artifactId>mockk-jvm</artifactId>
                 <version>${mockk.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>oauth2-oidc-sdk</artifactId>
+                <version>11.10</version>
             </dependency>
 
             <dependency>

--- a/sikkerhet/src/main/java/no/nav/familie/sikkerhet/ClientTokenValidationFilter.kt
+++ b/sikkerhet/src/main/java/no/nav/familie/sikkerhet/ClientTokenValidationFilter.kt
@@ -59,12 +59,7 @@ class ClientTokenValidationFilter(
 
     private fun accepted(): Boolean {
         try {
-            val claims = SpringTokenValidationContextHolder().tokenValidationContext.getClaims(issuerName)
-
-            if (claims == null) {
-                logger.warn("Finner ikke claim=$issuerName")
-                return false
-            }
+            val claims = SpringTokenValidationContextHolder().getTokenValidationContext().getClaims(issuerName)
 
             val sub = claims.get("sub") as String?
             val oid = claims.get("oid") as String?

--- a/sikkerhet/src/main/java/no/nav/familie/sikkerhet/EksternBrukerUtils.kt
+++ b/sikkerhet/src/main/java/no/nav/familie/sikkerhet/EksternBrukerUtils.kt
@@ -30,7 +30,9 @@ object EksternBrukerUtils {
 
     fun getBearerTokenForLoggedInUser(): String {
         return getFromContext { validationContext, issuer ->
-            validationContext.getJwtToken(issuer).tokenAsString
+            validationContext.getJwtToken(
+                issuer,
+            )?.encodedToken ?: throw JwtTokenValidatorException("Klarte ikke hente token fra issuer $issuer")
         }
     }
 

--- a/sikkerhet/src/main/java/no/nav/familie/sikkerhet/OIDCUtil.kt
+++ b/sikkerhet/src/main/java/no/nav/familie/sikkerhet/OIDCUtil.kt
@@ -15,7 +15,7 @@ class OIDCUtil(private val ctxHolder: TokenValidationContextHolder) {
     private lateinit var environment: Environment
 
     val subject: String?
-        get() = claimSet()?.subject
+        get() = claimSet().subject
 
     fun autentisertBruker(): String {
         return subject ?: jwtError("Fant ikke subject")
@@ -27,14 +27,14 @@ class OIDCUtil(private val ctxHolder: TokenValidationContextHolder) {
 
     fun getClaim(claim: String): String {
         return if (erDevProfil()) {
-            claimSet()?.get(claim)?.toString() ?: "DEV_$claim"
+            claimSet().get(claim)?.toString() ?: "DEV_$claim"
         } else {
-            claimSet()?.get(claim)?.toString() ?: jwtError("Fant ikke claim '$claim' i tokenet")
+            claimSet().get(claim)?.toString() ?: jwtError("Fant ikke claim '$claim' i tokenet")
         }
     }
 
     fun getClaimAsList(claim: String): List<String>? {
-        return if (erDevProfil()) listOf("group1") else claimSet()?.getAsList(claim)
+        return if (erDevProfil()) listOf("group1") else claimSet().getAsList(claim)
     }
 
     val navIdent: String
@@ -42,21 +42,21 @@ class OIDCUtil(private val ctxHolder: TokenValidationContextHolder) {
             if (erDevProfil()) {
                 "TEST_Z123"
             } else {
-                claimSet()?.get("NAVident")?.toString() ?: jwtError("Fant ikke NAVident")
+                claimSet().get("NAVident")?.toString() ?: jwtError("Fant ikke NAVident")
             }
 
     val groups: List<String>?
         get() =
-            (claimSet()?.get("groups") as List<*>?)
+            (claimSet().get("groups") as List<*>?)
                 ?.filterNotNull()
                 ?.map { it.toString() }
 
-    fun claimSet(): JwtTokenClaims? {
-        return context()?.getClaims("azuread")
+    fun claimSet(): JwtTokenClaims {
+        return context().getClaims("azuread")
     }
 
-    private fun context(): TokenValidationContext? {
-        return ctxHolder.tokenValidationContext
+    private fun context(): TokenValidationContext {
+        return ctxHolder.getTokenValidationContext()
     }
 
     val expiryDate: Date?

--- a/web-client/src/main/java/no/nav/familie/webflux/filter/BearerTokenFilter.kt
+++ b/web-client/src/main/java/no/nav/familie/webflux/filter/BearerTokenFilter.kt
@@ -1,10 +1,12 @@
 package no.nav.familie.webflux.filter
 
+import com.nimbusds.oauth2.sdk.GrantType
 import no.nav.familie.webflux.sts.StsTokenClient
 import no.nav.security.token.support.client.core.ClientProperties
 import no.nav.security.token.support.client.core.OAuth2GrantType
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
 import no.nav.security.token.support.client.spring.ClientConfigurationProperties
+import no.nav.security.token.support.core.exceptions.JwtTokenMissingException
 import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
 import org.springframework.context.annotation.Import
 import org.springframework.stereotype.Component
@@ -50,7 +52,7 @@ class BearerTokenClientCredentialFilter(
             clientConfigurationProperties,
             request,
             function,
-            OAuth2GrantType.CLIENT_CREDENTIALS,
+            GrantType.CLIENT_CREDENTIALS,
         )
     }
 }
@@ -122,7 +124,7 @@ private fun retrieveAndAddBearerToken(
     clientConfigurationProperties: ClientConfigurationProperties,
     request: ClientRequest,
     function: ExchangeFunction,
-    grantType: OAuth2GrantType? = null,
+    grantType: GrantType? = null,
 ): Mono<ClientResponse> {
     val accessToken =
         genererAccessToken(
@@ -151,7 +153,7 @@ private fun genererAccessToken(
     request: ClientRequest,
     clientConfigurationProperties: ClientConfigurationProperties,
     oAuth2AccessTokenService: OAuth2AccessTokenService,
-    grantType: OAuth2GrantType? = null,
+    grantType: GrantType? = null,
 ): String {
     val clientProperties =
         clientPropertiesFor(
@@ -159,7 +161,7 @@ private fun genererAccessToken(
             clientConfigurationProperties,
             grantType,
         )
-    return oAuth2AccessTokenService.getAccessToken(clientProperties).accessToken
+    return oAuth2AccessTokenService.getAccessToken(clientProperties).accessToken ?: throw JwtTokenMissingException()
 }
 
 /**
@@ -172,7 +174,7 @@ private fun genererAccessToken(
 private fun clientPropertiesFor(
     uri: URI,
     clientConfigurationProperties: ClientConfigurationProperties,
-    grantType: OAuth2GrantType?,
+    grantType: GrantType?,
 ): ClientProperties {
     val clientProperties = filterClientProperties(clientConfigurationProperties, uri)
     return if (grantType == null) {
@@ -196,7 +198,7 @@ private fun filterClientProperties(
 
 private fun clientPropertiesForGrantType(
     values: List<ClientProperties>,
-    grantType: OAuth2GrantType,
+    grantType: GrantType,
     uri: URI,
 ): ClientProperties {
     return values.firstOrNull { grantType == it.grantType }
@@ -208,7 +210,7 @@ private fun clientCredentialOrJwtBearer() = if (erSystembruker()) OAuth2GrantTyp
 private fun erSystembruker(): Boolean {
     return try {
         val preferredUsername =
-            SpringTokenValidationContextHolder().tokenValidationContext.getClaims("azuread")["preferred_username"]
+            SpringTokenValidationContextHolder().getTokenValidationContext().getClaims("azuread").get("preferred_username")
         return preferredUsername == null
     } catch (e: Exception) {
         // Ingen request context. Skjer ved kall som har opphav i kjørende applikasjon. Ping etc.

--- a/web-client/src/test/java/no/nav/familie/webflux/filter/BearerTokenFilterTest.kt
+++ b/web-client/src/test/java/no/nav/familie/webflux/filter/BearerTokenFilterTest.kt
@@ -43,7 +43,7 @@ class BearerTokenFilterTest {
 
         bearerTokenFilter.filter(req, execution)
 
-        verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration["1"]) }
+        verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration["1"]!!) }
     }
 
     @Test
@@ -56,7 +56,7 @@ class BearerTokenFilterTest {
 
         bearerTokenFilter.filter(req, execution)
 
-        verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration["2"]) }
+        verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration["2"]!!) }
     }
 
     private fun mockBrukerContext(preferredUsername: String) {


### PR DESCRIPTION
Viktigste endringer:
Må bruke RestClient i stedet for RestOperations.
Støtte for token i cookies er fjernet. 

Startet bare med en draft, da dette må testes og koordineres ift omskriving til RestClient