### PR TITLE
Branch for å bygge versjon 2 av felles med token-support 3.2.0 for de som fortsatt bruker spring 3.1.x og som trenger å få ut en bugfix i felles som skal ut i disse prosjektene. All kode som merges inn i denne branchen vil lage en versjon 2.x

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -43,17 +43,15 @@ jobs:
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: github.base_ref == 'main' && github.event.pull_request.merged == true
         run: |
           export GIT_COMMIT_HASH=$(git log -n 1 --pretty=format:'%h')
           export GIT_COMMIT_DATE=$(git log -1 --pretty='%ad' --date=format:'%Y%m%d%H%M%S')
-          export VERSION=3.${GIT_COMMIT_DATE}_${GIT_COMMIT_HASH}
+          export VERSION=2.${GIT_COMMIT_DATE}_${GIT_COMMIT_HASH}
           echo "Setting version $VERSION"
           mvn --settings .m2/maven-settings.xml versions:set -DnewVersion="$VERSION"
           mvn --settings .m2/maven-settings.xml versions:commit
 
       - name: Deploy to Github Package
-        if: github.base_ref == 'main' && github.event.pull_request.merged == true
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/http-client/src/main/java/no/nav/familie/http/client/RetryOAuth2HttpClient.kt
+++ b/http-client/src/main/java/no/nav/familie/http/client/RetryOAuth2HttpClient.kt
@@ -4,16 +4,16 @@ import no.nav.security.token.support.client.core.http.OAuth2HttpRequest
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenResponse
 import no.nav.security.token.support.client.spring.oauth2.DefaultOAuth2HttpClient
 import org.slf4j.LoggerFactory
+import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.core.NestedExceptionUtils
 import org.springframework.web.client.HttpServerErrorException
-import org.springframework.web.client.RestClient
 import java.net.SocketException
 import java.net.SocketTimeoutException
 
 class RetryOAuth2HttpClient(
-    restClient: RestClient,
+    restTemplateBuilder: RestTemplateBuilder,
     private val maxRetries: Int = 2,
-) : DefaultOAuth2HttpClient(restClient) {
+) : DefaultOAuth2HttpClient(restTemplateBuilder) {
     private val logger = LoggerFactory.getLogger(javaClass)
     private val secureLogger = LoggerFactory.getLogger("secureLogger")
 
@@ -25,7 +25,7 @@ class RetryOAuth2HttpClient(
             HttpServerErrorException.BadGateway::class,
         )
 
-    override fun post(oAuth2HttpRequest: OAuth2HttpRequest): OAuth2AccessTokenResponse {
+    override fun post(oAuth2HttpRequest: OAuth2HttpRequest): OAuth2AccessTokenResponse? {
         var retries = 0
 
         while (true) {

--- a/http-client/src/test/java/no/nav/familie/http/interceptor/BearerTokenClientCredentialsClientInterceptorTest.kt
+++ b/http-client/src/test/java/no/nav/familie/http/interceptor/BearerTokenClientCredentialsClientInterceptorTest.kt
@@ -34,7 +34,7 @@ internal class BearerTokenClientCredentialsClientInterceptorTest {
 
         bearerTokenClientInterceptor.intercept(req, ByteArray(0), execution)
 
-        verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration.get("1")!!) }
+        verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration["1"]) }
     }
 
     @Test
@@ -45,7 +45,7 @@ internal class BearerTokenClientCredentialsClientInterceptorTest {
         assertThat(catchThrowable { bearerTokenClientInterceptor.intercept(req, ByteArray(0), execution) })
             .hasMessage(
                 "could not find oauth2 client config for " +
-                    "uri=http://jwtResource.no and grant type=client_credentials",
+                    "uri=http://jwtResource.no and grant type=OAuth2GrantType[value=client_credentials]",
             )
     }
 }

--- a/http-client/src/test/java/no/nav/familie/http/interceptor/BearerTokenClientInterceptorTest.kt
+++ b/http-client/src/test/java/no/nav/familie/http/interceptor/BearerTokenClientInterceptorTest.kt
@@ -43,7 +43,7 @@ class BearerTokenClientInterceptorTest {
 
         bearerTokenClientInterceptor.intercept(req, ByteArray(0), execution)
 
-        verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration["1"]!!) }
+        verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration["1"]) }
     }
 
     @Test
@@ -56,7 +56,7 @@ class BearerTokenClientInterceptorTest {
 
         bearerTokenClientInterceptor.intercept(req, ByteArray(0), execution)
 
-        verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration["2"]!!) }
+        verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration["2"]) }
     }
 
     fun mockBrukerContext(preferredUsername: String) {

--- a/http-client/src/test/java/no/nav/familie/http/interceptor/BearerTokenOnBehalfOfClientInterceptorTest.kt
+++ b/http-client/src/test/java/no/nav/familie/http/interceptor/BearerTokenOnBehalfOfClientInterceptorTest.kt
@@ -33,7 +33,7 @@ internal class BearerTokenOnBehalfOfClientInterceptorTest {
 
         bearerTokenClientInterceptor.intercept(req, ByteArray(0), execution)
 
-        verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration["2"]!!) }
+        verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration["2"]) }
     }
 
     @Test
@@ -44,7 +44,7 @@ internal class BearerTokenOnBehalfOfClientInterceptorTest {
         Assertions.assertThat(Assertions.catchThrowable { bearerTokenClientInterceptor.intercept(req, ByteArray(0), execution) })
             .hasMessage(
                 "could not find oauth2 client config for " +
-                    "uri=http://clientResource.no and grant type=urn:ietf:params:oauth:grant-type:jwt-bearer",
+                    "uri=http://clientResource.no and grant type=OAuth2GrantType[value=urn:ietf:params:oauth:grant-type:jwt-bearer]",
             )
     }
 }

--- a/log/src/main/java/no/nav/familie/log/filter/RequestTimeFilter.kt
+++ b/log/src/main/java/no/nav/familie/log/filter/RequestTimeFilter.kt
@@ -44,7 +44,7 @@ open class RequestTimeFilter : Filter {
             }
         }
     }
-
+    
     open fun shouldNotFilter(uri: String): Boolean {
         return uri.contains("/internal") || uri == "/api/ping"
     }

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>3.2.3</version>
+                <version>3.2.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <kotest.version>5.8.0</kotest.version>
         <kotlin.version>1.9.22</kotlin.version>
         <mockk.version>1.13.9</mockk.version>
-        <nav.security.token.version>4.1.3</nav.security.token.version>
+        <nav.security.token.version>3.2.0</nav.security.token.version>
 
         <!--suppress UnresolvedMavenProperty  Ligger som secret i github-->
         <sonar.projectKey>${SONAR_PROJECTKEY}</sonar.projectKey>
@@ -88,11 +88,6 @@
                 <artifactId>mockk-jvm</artifactId>
                 <version>${mockk.version}</version>
                 <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.nimbusds</groupId>
-                <artifactId>oauth2-oidc-sdk</artifactId>
-                <version>11.10</version>
             </dependency>
 
             <dependency>

--- a/sikkerhet/src/main/java/no/nav/familie/sikkerhet/ClientTokenValidationFilter.kt
+++ b/sikkerhet/src/main/java/no/nav/familie/sikkerhet/ClientTokenValidationFilter.kt
@@ -59,7 +59,12 @@ class ClientTokenValidationFilter(
 
     private fun accepted(): Boolean {
         try {
-            val claims = SpringTokenValidationContextHolder().getTokenValidationContext().getClaims(issuerName)
+            val claims = SpringTokenValidationContextHolder().tokenValidationContext.getClaims(issuerName)
+
+            if (claims == null) {
+                logger.warn("Finner ikke claim=$issuerName")
+                return false
+            }
 
             val sub = claims.get("sub") as String?
             val oid = claims.get("oid") as String?

--- a/sikkerhet/src/main/java/no/nav/familie/sikkerhet/EksternBrukerUtils.kt
+++ b/sikkerhet/src/main/java/no/nav/familie/sikkerhet/EksternBrukerUtils.kt
@@ -30,9 +30,7 @@ object EksternBrukerUtils {
 
     fun getBearerTokenForLoggedInUser(): String {
         return getFromContext { validationContext, issuer ->
-            validationContext.getJwtToken(
-                issuer,
-            )?.encodedToken ?: throw JwtTokenValidatorException("Klarte ikke hente token fra issuer $issuer")
+            validationContext.getJwtToken(issuer).tokenAsString
         }
     }
 

--- a/sikkerhet/src/main/java/no/nav/familie/sikkerhet/OIDCUtil.kt
+++ b/sikkerhet/src/main/java/no/nav/familie/sikkerhet/OIDCUtil.kt
@@ -15,7 +15,7 @@ class OIDCUtil(private val ctxHolder: TokenValidationContextHolder) {
     private lateinit var environment: Environment
 
     val subject: String?
-        get() = claimSet().subject
+        get() = claimSet()?.subject
 
     fun autentisertBruker(): String {
         return subject ?: jwtError("Fant ikke subject")
@@ -27,14 +27,14 @@ class OIDCUtil(private val ctxHolder: TokenValidationContextHolder) {
 
     fun getClaim(claim: String): String {
         return if (erDevProfil()) {
-            claimSet().get(claim)?.toString() ?: "DEV_$claim"
+            claimSet()?.get(claim)?.toString() ?: "DEV_$claim"
         } else {
-            claimSet().get(claim)?.toString() ?: jwtError("Fant ikke claim '$claim' i tokenet")
+            claimSet()?.get(claim)?.toString() ?: jwtError("Fant ikke claim '$claim' i tokenet")
         }
     }
 
     fun getClaimAsList(claim: String): List<String>? {
-        return if (erDevProfil()) listOf("group1") else claimSet().getAsList(claim)
+        return if (erDevProfil()) listOf("group1") else claimSet()?.getAsList(claim)
     }
 
     val navIdent: String
@@ -42,21 +42,21 @@ class OIDCUtil(private val ctxHolder: TokenValidationContextHolder) {
             if (erDevProfil()) {
                 "TEST_Z123"
             } else {
-                claimSet().get("NAVident")?.toString() ?: jwtError("Fant ikke NAVident")
+                claimSet()?.get("NAVident")?.toString() ?: jwtError("Fant ikke NAVident")
             }
 
     val groups: List<String>?
         get() =
-            (claimSet().get("groups") as List<*>?)
+            (claimSet()?.get("groups") as List<*>?)
                 ?.filterNotNull()
                 ?.map { it.toString() }
 
-    fun claimSet(): JwtTokenClaims {
-        return context().getClaims("azuread")
+    fun claimSet(): JwtTokenClaims? {
+        return context()?.getClaims("azuread")
     }
 
-    private fun context(): TokenValidationContext {
-        return ctxHolder.getTokenValidationContext()
+    private fun context(): TokenValidationContext? {
+        return ctxHolder.tokenValidationContext
     }
 
     val expiryDate: Date?

--- a/web-client/src/test/java/no/nav/familie/webflux/filter/BearerTokenFilterTest.kt
+++ b/web-client/src/test/java/no/nav/familie/webflux/filter/BearerTokenFilterTest.kt
@@ -43,7 +43,7 @@ class BearerTokenFilterTest {
 
         bearerTokenFilter.filter(req, execution)
 
-        verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration["1"]!!) }
+        verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration["1"]) }
     }
 
     @Test
@@ -56,7 +56,7 @@ class BearerTokenFilterTest {
 
         bearerTokenFilter.filter(req, execution)
 
-        verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration["2"]!!) }
+        verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration["2"]) }
     }
 
     private fun mockBrukerContext(preferredUsername: String) {


### PR DESCRIPTION
- **Revert "Bump org.springframework.boot:spring-boot-dependencies from 3.2.2 to 3.2.3 (#777)"**
- **Bygg versjon 2**
- **Revert "Oppgradering til token-support 4.1.3**

Branch for å bygge versjon 2 av felles med token-support 3.2.0 for de som fortsatt bruker spring 3.1.x. Endringer som committes inn her vil bygges til en release av felles 2.x. For de som ikke kan oppgradere til restClient pga Spring boot 3.2 problemer
