### PR TITLE
Trenger ikke å logge 4XX-feil som warning - dette er oftest brukerfei…

### DIFF
--- a/log/src/main/java/no/nav/familie/log/filter/RequestTimeFilter.kt
+++ b/log/src/main/java/no/nav/familie/log/filter/RequestTimeFilter.kt
@@ -36,7 +36,7 @@ open class RequestTimeFilter : Filter {
         code: Int,
         timer: StopWatch,
     ) {
-        if (HttpStatus.valueOf(code).isError) {
+        if (HttpStatus.valueOf(code).is5xxServerError) {
             LOG.warn("{} - {} - ({}). Dette tok {}ms", request.method, request.requestURI, code, timer.totalTimeMillis)
         } else {
             if (!shouldNotFilter(request.requestURI)) {


### PR DESCRIPTION
…l i en eller annen kontekst. 5XX-feil kan fint logges som warning.

Som vakt opplever jeg mye unødig støy rundt 400-feil fordi folk gjør søk i løsningen med input som enten ikke er gyldig, eller personer som ikke finnes i EF. 

Ellers er det fair å logge 5XX-requestene som warning. 

Hva tenker dere på BAKS?