### PR TITLE
Fjern tracking cookie for eksterne brukerflater

### DIFF
--- a/log/src/main/java/no/nav/familie/log/NavSystemtype.kt
+++ b/log/src/main/java/no/nav/familie/log/NavSystemtype.kt
@@ -1,0 +1,8 @@
+package no.nav.familie.log
+
+enum class NavSystemtype {
+    NAV_EKSTERN_BRUKERFLATE,
+    NAV_SAKSBEHANDLINGSSYSTEM,
+    NAV_INTEGRASJON,
+    ;
+}

--- a/log/src/main/java/no/nav/familie/log/filter/LogFilter.kt
+++ b/log/src/main/java/no/nav/familie/log/filter/LogFilter.kt
@@ -9,6 +9,7 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import no.nav.familie.log.IdUtils
 import no.nav.familie.log.NavHttpHeaders
+import no.nav.familie.log.NavSystemtype
 import no.nav.familie.log.mdc.MDCConstants.MDC_CALL_ID
 import no.nav.familie.log.mdc.MDCConstants.MDC_CONSUMER_ID
 import no.nav.familie.log.mdc.MDCConstants.MDC_REQUEST_ID
@@ -27,6 +28,7 @@ class LogFilter(
      */
     private val exposeErrorDetails: Supplier<Boolean> = Supplier { false },
     private val serverName: String? = null,
+    private val systemtype: NavSystemtype
 ) : HttpFilter() {
     @Throws(ServletException::class, IOException::class)
     override fun doFilter(
@@ -35,7 +37,8 @@ class LogFilter(
         filterChain: FilterChain,
     ) {
         val userId = resolveUserId(httpServletRequest)
-        if (userId == null || userId.isEmpty()) {
+        val skalGenerereBrukerIdCookie = systemtype == NavSystemtype.NAV_SAKSBEHANDLINGSSYSTEM && userId.isNullOrEmpty()
+        if (skalGenerereBrukerIdCookie) {
             // user-id tracking only works if the client is stateful and supports cookies.
             // if no user-id is found, generate one for any following requests but do not use it on the
             // current request to avoid generating large numbers of useless user-ids.
@@ -43,8 +46,12 @@ class LogFilter(
         }
         val consumerId = httpServletRequest.getHeader(NavHttpHeaders.NAV_CONSUMER_ID.asString())
         val callId = resolveCallId(httpServletRequest)
+
+        if(systemtype == NavSystemtype.NAV_SAKSBEHANDLINGSSYSTEM || systemtype == NavSystemtype.NAV_INTEGRASJON) {
+            MDC.put(MDC_USER_ID, userId)
+        }
+
         MDC.put(MDC_CALL_ID, callId)
-        MDC.put(MDC_USER_ID, userId)
         MDC.put(MDC_CONSUMER_ID, consumerId)
         MDC.put(MDC_REQUEST_ID, resolveRequestId(httpServletRequest))
         httpServletResponse.setHeader(NavHttpHeaders.NAV_CALL_ID.asString(), callId)

--- a/log/src/main/java/no/nav/familie/log/filter/LogFilter.kt
+++ b/log/src/main/java/no/nav/familie/log/filter/LogFilter.kt
@@ -26,9 +26,9 @@ class LogFilter(
      * that will return whether stacktraces should be exposed or not
      * Defaults to always false
      */
+    private val systemtype: NavSystemtype,
     private val exposeErrorDetails: Supplier<Boolean> = Supplier { false },
     private val serverName: String? = null,
-    private val systemtype: NavSystemtype
 ) : HttpFilter() {
     @Throws(ServletException::class, IOException::class)
     override fun doFilter(
@@ -47,7 +47,7 @@ class LogFilter(
         val consumerId = httpServletRequest.getHeader(NavHttpHeaders.NAV_CONSUMER_ID.asString())
         val callId = resolveCallId(httpServletRequest)
 
-        if(systemtype == NavSystemtype.NAV_SAKSBEHANDLINGSSYSTEM || systemtype == NavSystemtype.NAV_INTEGRASJON) {
+        if (systemtype in listOf(NavSystemtype.NAV_SAKSBEHANDLINGSSYSTEM, NavSystemtype.NAV_INTEGRASJON)) {
             MDC.put(MDC_USER_ID, userId)
         }
 

--- a/log/src/test/java/no/nav/familie/log/filter/LogFilterTest.kt
+++ b/log/src/test/java/no/nav/familie/log/filter/LogFilterTest.kt
@@ -2,9 +2,13 @@ package no.nav.familie.log.filter
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
+import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import no.nav.familie.log.NavHttpHeaders
+import no.nav.familie.log.NavSystemtype
+import no.nav.familie.log.mdc.MDCConstants.MDC_USER_ID
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -13,7 +17,9 @@ import org.slf4j.MDC
 class LogFilterTest {
     private lateinit var httpServletRequest: HttpServletRequest
     private lateinit var httpServletResponse: HttpServletResponse
-    private val logFilter = LogFilter()
+    private val logFilter = LogFilter(systemtype = NavSystemtype.NAV_SAKSBEHANDLINGSSYSTEM)
+    private val logFilterForEksternBrukerflate = LogFilter(systemtype = NavSystemtype.NAV_EKSTERN_BRUKERFLATE)
+    private val logFilterForIntegrasjon = LogFilter(systemtype = NavSystemtype.NAV_INTEGRASJON)
 
     @BeforeEach
     fun setup() {
@@ -52,6 +58,51 @@ class LogFilterTest {
             .isEqualTo(HttpServletResponse.SC_INTERNAL_SERVER_ERROR)
     }
 
+    @Test
+    fun `skal hente ut brukerIdToken hvis loggeren brukes av saksbehandlingsløsning og cookien finnes`() {
+        logFilter.doFilter(mockHttpServletRequestMedCookie, httpServletResponse) { _, _ ->
+            assertThat(MDC.get(MDC_USER_ID)).isEqualTo("1234")
+            verify(exactly = 0) { httpServletResponse.addCookie(any()) }
+        }
+    }
+
+    @Test
+    fun `skal generere brukerIdToken hvis loggeren brukes av saksbehandlingsløsning og cookien ikke finnes fra før av`() {
+        logFilter.doFilter(mockHttpServletRequest, httpServletResponse) { _, _ ->
+            verify(exactly = 1) { httpServletResponse.addCookie(any()) }
+        }
+    }
+
+    @Test
+    fun `skal ikke generere brukerIdToken hvis loggeren brukes av ekstern brukerflate`() {
+        logFilterForEksternBrukerflate.doFilter(mockHttpServletRequest, httpServletResponse) { _, _ ->
+            verify(exactly = 0) { httpServletResponse.addCookie(any()) }
+        }
+    }
+
+    @Test
+    fun `skal ikke hente ut brukerIdToken hvis loggeren brukes av ekstern brukerflate og cookie finnes`() {
+        logFilterForEksternBrukerflate.doFilter(mockHttpServletRequestMedCookie, httpServletResponse) { _, _ ->
+            verify(exactly = 0) { httpServletResponse.addCookie(any()) }
+            assertThat(MDC.get(MDC_USER_ID)).isNull()
+        }
+    }
+
+    @Test
+    fun `skal ikke generere brukerIdToken hvis loggeren brukes av integrasjoner og cookien ikke finnes`() {
+        logFilterForIntegrasjon.doFilter(mockHttpServletRequest, httpServletResponse) { _, _ ->
+            verify(exactly = 0) { httpServletResponse.addCookie(any()) }
+        }
+    }
+
+    @Test
+    fun `skal generere brukerIdToken hvis loggeren brukes av integrasjoner og cookien allerede finnes`() {
+        logFilterForIntegrasjon.doFilter(mockHttpServletRequestMedCookie, httpServletResponse) { _, _ ->
+            verify(exactly = 0) { httpServletResponse.addCookie(any()) }
+            assertThat(MDC.get(MDC_USER_ID)).isEqualTo("1234")
+        }
+    }
+
     companion object {
         private fun fail(): Unit = throw IllegalStateException("")
 
@@ -62,6 +113,17 @@ class LogFilterTest {
                 val request: HttpServletRequest = mockk(relaxed = true)
                 every { request.method } returns method
                 every { request.requestURI } returns requestUri
+                return request
+            }
+
+        private val mockHttpServletRequestMedCookie: HttpServletRequest
+            get() {
+                val method = "GET"
+                val requestUri = "/test/path"
+                val request: HttpServletRequest = mockk(relaxed = true)
+                every { request.method } returns method
+                every { request.requestURI } returns requestUri
+                every {request.cookies} returns arrayOf(Cookie("RUIDC","1234"))
                 return request
             }
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <url>https://github.com/navikt/familie-felles</url>
 
     <properties>
-        <revision>3.4</revision>
+        <revision>4.0</revision>
         <sha1/>
         <changelist>-SNAPSHOT</changelist>
         <java.version>21</java.version>


### PR DESCRIPTION
Fjerner tracking cookie for eksterne brukerflater nå som vi muligens trenger ekstra samtykke for å beholde en slik cookie. Jobben for å kunne skru den av hvis samtykke mangler er mye større enn verdien av å bruke denne cookien for eksterne brukere. 

Vi har fremdeles mulighet for å bruke denne cookien i saksbehandlingsløsninger og integrasjonsapplikasjoner. Innfører dermed en breaking change på `LogFilter`, der man nå må sende inn hvilken systemtype applikasjonen er for å kunne bestemme om tracking cookien skal settes eller ikke.

Når man oppdaterer denne dependencien på appene våre må vi ta stilling til hvilken systemtype vi ønsker å bruke:
- `NavSystemtype.NAV_SAKSBEHANDLINGSSYSTEM` vil fremdeles generere tracking cookie og bruke den i logger.
- `NavSystemtype.NAV_INTEGRASJON` vil ikke generere egen tracking cookie men vil bruke den i logger hvis den allerede eksisterer.
- `NavSystemtype.NAV_EKSTERN_BRUKERFLATE` vil hverken generere cookie eller bruke den i logger.