### PR TITLE
Revert major version bump, versjonen er hardkodet til 3.x uansett

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <url>https://github.com/navikt/familie-felles</url>
 
     <properties>
-        <revision>4.0</revision>
+        <revision>3.4</revision>
         <sha1/>
         <changelist>-SNAPSHOT</changelist>
         <java.version>21</java.version>


### PR DESCRIPTION
Siden vi i byggescriptet [hardkoder versjonen til 3.x](https://github.com/navikt/familie-felles/blob/main/.github/workflows/build-deploy.yml#L50) gir det ikke mening å oppdatere pom-en slik jeg gjorde. Reverter.