### PR TITLE
Lagt til retry med delay på reader for å minske antall alarmer når sidecaren går ned før appen

### DIFF
--- a/leader/src/main/kotlin/no/nav/familie/leader/Environment.kt
+++ b/leader/src/main/kotlin/no/nav/familie/leader/Environment.kt
@@ -3,6 +3,6 @@ package no.nav.familie.leader
 object Environment {
     @JvmStatic
     fun hentLeaderSystemEnv(): String? {
-        return System.getenv("ELECTOR_PATH") ?: return null
+        return System.getenv("ELECTOR_GET_URL") ?: return null
     }
 }

--- a/leader/src/main/kotlin/no/nav/familie/leader/LeaderClient.kt
+++ b/leader/src/main/kotlin/no/nav/familie/leader/LeaderClient.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.leader
 
+import org.slf4j.LoggerFactory
 import java.net.InetAddress
 import java.net.URI
 import java.net.http.HttpClient
@@ -8,25 +9,54 @@ import java.net.http.HttpResponse
 import java.net.http.HttpResponse.BodyHandlers
 
 object LeaderClient {
+    private val logger = LoggerFactory.getLogger(LeaderClient::class.java)
+
     /**
      * @return Om pod er leader eller ikke. null hvis leadersjekk ikke er implementert på pod
      */
     @JvmStatic
-    fun isLeader(): Boolean? {
-        val electorPath = Environment.hentLeaderSystemEnv() ?: return null
+    fun isLeader(
+        antallGanger: Int = 3,
+        forsinkelseIms: Long = 1000,
+    ): Boolean? {
+        val electorGetUrl = Environment.hentLeaderSystemEnv() ?: return null
 
         val client = HttpClient.newHttpClient()
         val request =
             HttpRequest
                 .newBuilder()
-                .uri(URI.create("http://$electorPath"))
+                .uri(URI.create(electorGetUrl))
                 .GET()
                 .build()
 
-        val response: HttpResponse<String> = client.send(request, BodyHandlers.ofString())
-        if (response.body().isNullOrBlank()) return null
+        val response: HttpResponse<String>? =
+            retryFunksjon(
+                antallGanger = antallGanger,
+                forsinkelseIms = forsinkelseIms,
+            ) { client.send(request, BodyHandlers.ofString()) }
+
+        if (response?.body().isNullOrBlank()) return null
 
         val hostname: String = InetAddress.getLocalHost().hostName
-        return response.body().contains(hostname)
+        return response?.body()?.contains(hostname)
+    }
+
+    private fun <T> retryFunksjon(
+        antallGanger: Int = 3,
+        forsinkelseIms: Long = 1000,
+        funksjon: () -> T,
+    ): T? {
+        var throwable: Exception? = null
+        repeat(antallGanger) {
+            try {
+                return funksjon()
+            } catch (e: Exception) {
+                logger.warn("Kunne ikke hente leader status")
+                throwable = e
+            }
+            Thread.sleep(forsinkelseIms)
+        }
+        logger.error("Kunne ikke hente leader status", throwable)
+        return null
     }
 }

--- a/leader/src/test/kotlin/no/nav/familie/leader/LeaderClientTest.kt
+++ b/leader/src/test/kotlin/no/nav/familie/leader/LeaderClientTest.kt
@@ -49,7 +49,7 @@ class LeaderClientTest {
     @Test
     fun `Skal returnere true hvis pod er leader`() {
         mockkStatic(Environment::class)
-        every { Environment.hentLeaderSystemEnv() } returns "localhost:${wireMockServer.port()}"
+        every { Environment.hentLeaderSystemEnv() } returns "http://localhost:${wireMockServer.port()}"
         wireMockServer.stubFor(
             get(anyUrl())
                 .willReturn(
@@ -64,7 +64,7 @@ class LeaderClientTest {
     @Test
     fun `Skal returnere false hvis pod ikke er leader`() {
         mockkStatic(Environment::class)
-        every { Environment.hentLeaderSystemEnv() } returns "localhost:${wireMockServer.port()}"
+        every { Environment.hentLeaderSystemEnv() } returns "http://localhost:${wireMockServer.port()}"
         wireMockServer.stubFor(
             get(anyUrl())
                 .willReturn(
@@ -79,7 +79,7 @@ class LeaderClientTest {
     @Test
     fun `Skal returnere null hvis response er tom`() {
         mockkStatic(Environment::class)
-        every { Environment.hentLeaderSystemEnv() } returns "localhost:${wireMockServer.port()}"
+        every { Environment.hentLeaderSystemEnv() } returns "http://localhost:${wireMockServer.port()}"
         wireMockServer.stubFor(
             get(anyUrl())
                 .willReturn(
@@ -89,5 +89,13 @@ class LeaderClientTest {
         )
 
         assertNull(LeaderClient.isLeader())
+    }
+
+    @Test
+    fun `Skal returnere null hvis leader ikke svarer`() {
+        mockkStatic(Environment::class)
+        every { Environment.hentLeaderSystemEnv() } returns "http://leaderErNede:9999"
+
+        assertNull(LeaderClient.isLeader(antallGanger = 3, forsinkelseIms = 1))
     }
 }


### PR DESCRIPTION
NAV-23684
Lagt til en retry med delay på isLeader. Ser at sidecaren for leader går ned før appen ved redeploy. Muligens at en retry med delay på maks 3s ikke er nok, men samtidig ønsker man ikke for treg isLeader før den feiler. 

Hvis ikke 3s er nok så tenker jeg man kan fjerne error-loggingen. Siden tjenesten vil returnerer null hvis leader er nede.

Også byttet til den oppdaterte ENV-verdien man skal bruke, siden ELECTOR_PATH er gammel måte.