### PR TITLE
Fjerner trailing slash i ECB url

### DIFF
--- a/valutakurs-klient/src/main/java/no/nav/familie/valutakurs/ValutakursRestClient.kt
+++ b/valutakurs-klient/src/main/java/no/nav/familie/valutakurs/ValutakursRestClient.kt
@@ -41,7 +41,7 @@ class ValutakursRestClient(
             URI.create(
                 "${ecbApiUrl}${frequency.toFrequencyParam()}.${toCurrencyParams(
                     currencies,
-                )}.EUR.SP00.A/${frequency.toQueryParams(exchangeRateDate)}",
+                )}.EUR.SP00.A${frequency.toQueryParams(exchangeRateDate)}",
             )
         try {
             HttpHeaders().apply {

--- a/valutakurs-klient/src/test/java/no/nav/familie/valutakurs/ValutakursRestClientTest.kt
+++ b/valutakurs-klient/src/test/java/no/nav/familie/valutakurs/ValutakursRestClientTest.kt
@@ -72,7 +72,7 @@ class ValutakursRestClientTest {
             )
         wireMockServer.stubFor(
             WireMock
-                .get("/D.SEK+NOK.EUR.SP00.A/?startPeriod=$valutakursDato&endPeriod=$valutakursDato")
+                .get("/D.SEK+NOK.EUR.SP00.A?startPeriod=$valutakursDato&endPeriod=$valutakursDato")
                 .willReturn(
                     WireMock
                         .aResponse()
@@ -98,7 +98,7 @@ class ValutakursRestClientTest {
         val body = createECBResponseBody(Frequency.Daily, listOf(Pair("NOK", BigDecimal.valueOf(10.337))), valutakursDato.toString())
         wireMockServer.stubFor(
             WireMock
-                .get("/D.NOK+EUR.EUR.SP00.A/?startPeriod=$valutakursDato&endPeriod=$valutakursDato")
+                .get("/D.NOK+EUR.EUR.SP00.A?startPeriod=$valutakursDato&endPeriod=$valutakursDato")
                 .willReturn(
                     WireMock
                         .aResponse()
@@ -124,7 +124,7 @@ class ValutakursRestClientTest {
             createECBResponseBody(Frequency.Monthly, listOf(Pair("NOK", BigDecimal.valueOf(10.337))), YearMonth.of(2022, 6).toString())
         wireMockServer.stubFor(
             WireMock
-                .get("/M.NOK.EUR.SP00.A/?endPeriod=$valutakursDato&lastNObservations=1")
+                .get("/M.NOK.EUR.SP00.A?endPeriod=$valutakursDato&lastNObservations=1")
                 .willReturn(
                     WireMock
                         .aResponse()
@@ -145,7 +145,7 @@ class ValutakursRestClientTest {
             createECBResponseBody(Frequency.Monthly, listOf(Pair("NOK", BigDecimal.valueOf(10.337))), YearMonth.of(2022, 7).toString())
         wireMockServer.stubFor(
             WireMock
-                .get("/M.NOK.EUR.SP00.A/?endPeriod=$valutakursDato&lastNObservations=1")
+                .get("/M.NOK.EUR.SP00.A?endPeriod=$valutakursDato&lastNObservations=1")
                 .willReturn(
                     WireMock
                         .aResponse()
@@ -165,7 +165,7 @@ class ValutakursRestClientTest {
         val body = ""
         wireMockServer.stubFor(
             WireMock
-                .get("/D.NOK+SEK.EUR.SP00.A/?startPeriod=$valutakursDato&endPeriod=$valutakursDato")
+                .get("/D.NOK+SEK.EUR.SP00.A?startPeriod=$valutakursDato&endPeriod=$valutakursDato")
                 .willReturn(
                     WireMock
                         .aResponse()
@@ -191,7 +191,7 @@ class ValutakursRestClientTest {
         val body = ""
         wireMockServer.stubFor(
             WireMock
-                .get("/D.NOK+SEK.EUR.SP00.A/?startPeriod=$valutakursDato&endPeriod=$valutakursDato")
+                .get("/D.NOK+SEK.EUR.SP00.A?startPeriod=$valutakursDato&endPeriod=$valutakursDato")
                 .willReturn(
                     WireMock
                         .aResponse()
@@ -218,7 +218,7 @@ class ValutakursRestClientTest {
         val body = createIncompleteECBResponseBody(listOf(Pair("NOK", BigDecimal.valueOf(10.337))), YearMonth.of(2022, 7).toString())
         wireMockServer.stubFor(
             WireMock
-                .get("/D.NOK.EUR.SP00.A/?startPeriod=$valutakursDato&endPeriod=$valutakursDato")
+                .get("/D.NOK.EUR.SP00.A?startPeriod=$valutakursDato&endPeriod=$valutakursDato")
                 .willReturn(
                     WireMock
                         .aResponse()
@@ -239,7 +239,7 @@ class ValutakursRestClientTest {
         val body = createECBResponseBody(Frequency.Daily, listOf(Pair("NOK", BigDecimal.valueOf(10.337))), YearMonth.of(2022, 7).toString())
         wireMockServer.stubFor(
             WireMock
-                .get("/D.NOK.EUR.SP00.A/?startPeriod=$valutakursDato&endPeriod=$valutakursDato")
+                .get("/D.NOK.EUR.SP00.A?startPeriod=$valutakursDato&endPeriod=$valutakursDato")
                 .willReturn(
                     WireMock
                         .aResponse()


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24455

Fra rundt 08:30 tiden i dag så har vi hatt noe feil når vi prøver å nå ECB.
Dette kan også reproduseres i test.
    "melding": "404  on GET request for \"https://data-api.ecb.europa.eu/service/data/EXR/D.NOK+SEK.EUR.SP00.A/\": [no body]",
    
Når man forsøker dette:
➤ curl https://data-api.ecb.europa.eu/service/data/EXR/D.NOK+PLN.EUR.SP00.A/ så får man 404.

Forsøker man dette
➤ curl https://data-api.ecb.europa.eu/service/data/EXR/D.NOK+PLN.EUR.SP00.A  så funker det.

Har de sluttet å støtte trailing slash?
Uanset hva det er, vi fjerner trailing slash hos oss.