### PR TITLE
Begrens klipping av en tidslinje til start- og sluttidspunkt for tidslinjen

### DIFF
--- a/tidslinje/src/test/kotlin/no/nav/familie/tidslinje/utvidelser/SnittOgKlippTest.kt
+++ b/tidslinje/src/test/kotlin/no/nav/familie/tidslinje/utvidelser/SnittOgKlippTest.kt
@@ -5,7 +5,7 @@ import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.TidslinjePeriode
 import no.nav.familie.tidslinje.Udefinert
 import no.nav.familie.tidslinje.Verdi
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
@@ -47,15 +47,15 @@ class SnittOgKlippTest {
 
         val fasit = mutableListOf(2, 4, 30)
 
-        Assertions.assertEquals(
+        assertEquals(
             fasit,
             resultat.innhold.map { it.periodeVerdi.verdi }.toList(),
             "Kunne ikke addere to tidslinjer med ulik slutt på månedsnivå",
         )
-        Assertions.assertEquals(resultat.tidsEnhet, TidsEnhet.MÅNED)
+        assertEquals(resultat.tidsEnhet, TidsEnhet.MÅNED)
 
         val endDate = LocalDate.of(2022, 2, 1).plusMonths(3)
-        Assertions.assertEquals(endDate.withDayOfMonth(endDate.lengthOfMonth()), resultat.kalkulerSluttTidspunkt())
+        assertEquals(endDate.withDayOfMonth(endDate.lengthOfMonth()), resultat.kalkulerSluttTidspunkt())
     }
 
     @Test
@@ -79,9 +79,9 @@ class SnittOgKlippTest {
 
         tidslinje = tidslinje.klipp(startDato, sluttDato)
 
-        Assertions.assertEquals(fasit, tidslinje.innhold.map { it.periodeVerdi.verdi }.toList())
-        Assertions.assertEquals(startDato, tidslinje.startsTidspunkt)
-        Assertions.assertEquals(sluttDato, tidslinje.kalkulerSluttTidspunkt())
+        assertEquals(fasit, tidslinje.innhold.map { it.periodeVerdi.verdi }.toList())
+        assertEquals(startDato, tidslinje.startsTidspunkt)
+        assertEquals(sluttDato, tidslinje.kalkulerSluttTidspunkt())
 
         tidslinje =
             Tidslinje(
@@ -102,8 +102,25 @@ class SnittOgKlippTest {
 
         tidslinje = tidslinje.konverterTilDag().klipp(startDato, sluttDato)
 
-        Assertions.assertEquals(fasit, tidslinje.innhold.map { it.periodeVerdi.verdi }.toList())
-        Assertions.assertEquals(startDato, tidslinje.startsTidspunkt)
-        Assertions.assertEquals(sluttDato, tidslinje.kalkulerSluttTidspunkt())
+        assertEquals(fasit, tidslinje.innhold.map { it.periodeVerdi.verdi }.toList())
+        assertEquals(startDato, tidslinje.startsTidspunkt)
+        assertEquals(sluttDato, tidslinje.kalkulerSluttTidspunkt())
+    }
+
+    @Test
+    fun `klipping av tidslinje utenfor tidslinje gjør ingenting`() {
+        val tidslinje =
+            Tidslinje(
+                startsTidspunkt = LocalDate.of(2025, 1, 1),
+                perioder = listOf(TidslinjePeriode(periodeVerdi = 1, lengde = 10, erUendelig = false)),
+                tidsEnhet = TidsEnhet.MÅNED,
+            )
+
+        val startDato = LocalDate.MIN
+        val sluttDato = LocalDate.MAX
+
+        val klippetTidslinje = tidslinje.klipp(startDato, sluttDato)
+
+        assertEquals(tidslinje, klippetTidslinje)
     }
 }


### PR DESCRIPTION
Ettersom `TidslinjePeriode::erUendelig` settes til `true` dersom `lengde` er større enn `INF` (1000000000), vil perioder som starter `LocalDate.MIN` defineres som uendelig, selv om det kommer perioder etter.
Det gir ikke mening å klipp en tidslinje utenfor starttidspunkt og sluttidspunkt, så problemet løses ved å begrense klipping av tidslinjer til periodene tidslinjen strekker seg over