### PR TITLE
Juster nede logger for leader

### DIFF
--- a/leader/src/main/kotlin/no/nav/familie/leader/LeaderClient.kt
+++ b/leader/src/main/kotlin/no/nav/familie/leader/LeaderClient.kt
@@ -51,12 +51,12 @@ object LeaderClient {
             try {
                 return funksjon()
             } catch (e: Exception) {
-                logger.warn("Kunne ikke hente leader status")
+                logger.info("Kunne ikke hente leader status")
                 throwable = e
             }
             Thread.sleep(forsinkelseIms)
         }
-        logger.error("Kunne ikke hente leader status", throwable)
+        logger.warn("Kunne ikke hente leader status", throwable)
         return null
     }
 }


### PR DESCRIPTION
Leader kaster error ofte ved redeploy eller nedskalering fordi leader-endepunktet forsvinner mens den kjører en Scheduled task. Noe som skjer ofte i ba-sak, siden man der har noen jobber som kjører regelmessig over poddene. Dette ser ut til å skje før graceful er mottatt sidene de jobbene nå er satt opp med graceful shutdown. 

Endepunktet kaster null hvis det ikke er et leader-endepunkt tilgjenglig, som betyr det samme som at pod ikke er leader. Så ser det som trygt å skru ned loggnivå.