### PR TITLE
Klipping av fom på uendelig tidslinje skal beholde uendelighet

### DIFF
--- a/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/TidslinjeUtvidelser.kt
+++ b/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/TidslinjeUtvidelser.kt
@@ -258,6 +258,7 @@ fun <T> Tidslinje<T>.klipp(
 ): Tidslinje<T> {
     val foreldre = this.foreldre
 
+    val erUendelig = sluttTidspunkt >= kalkulerSluttTidspunkt() && innhold.any { it.erUendelig }
     val justertStartTidspunkt = maxOf(this.startsTidspunkt, startTidspunkt)
     val justertSluttTidspunkt = minOf(this.kalkulerSluttTidspunkt(), sluttTidspunkt).plusDays(1)
 
@@ -265,14 +266,16 @@ fun <T> Tidslinje<T>.klipp(
         if (justertSluttTidspunkt.isAfter(justertStartTidspunkt)) {
             val tidslinjeKlipp =
                 Tidslinje(
-                    justertStartTidspunkt,
-                    listOf(
-                        TidslinjePeriode(
-                            periodeVerdi = true,
-                            lengde = justertStartTidspunkt.until(justertSluttTidspunkt, mapper[this.tidsEnhet]),
+                    startsTidspunkt = justertStartTidspunkt,
+                    perioder =
+                        listOf(
+                            TidslinjePeriode(
+                                periodeVerdi = true,
+                                lengde = justertStartTidspunkt.until(justertSluttTidspunkt, mapper[this.tidsEnhet]),
+                                erUendelig = erUendelig,
+                            ),
                         ),
-                    ),
-                    this.tidsEnhet,
+                    tidsEnhet = this.tidsEnhet,
                 )
             this
                 .biFunksjon(tidslinjeKlipp) { status1, status2 ->

--- a/tidslinje/src/test/kotlin/no/nav/familie/tidslinje/utvidelser/SnittOgKlippTest.kt
+++ b/tidslinje/src/test/kotlin/no/nav/familie/tidslinje/utvidelser/SnittOgKlippTest.kt
@@ -6,6 +6,7 @@ import no.nav.familie.tidslinje.TidslinjePeriode
 import no.nav.familie.tidslinje.Udefinert
 import no.nav.familie.tidslinje.Verdi
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
@@ -122,5 +123,27 @@ class SnittOgKlippTest {
         val klippetTidslinje = tidslinje.klipp(startDato, sluttDato)
 
         assertEquals(tidslinje, klippetTidslinje)
+    }
+
+    @Test
+    fun `klipping av fom skal ikke gjøre en uendelig tidslinje endelig`() {
+        val tidslinje =
+            Tidslinje(
+                startsTidspunkt = LocalDate.of(0, 1, 1),
+                perioder =
+                    listOf(
+                        TidslinjePeriode(periodeVerdi = 970, lengde = 737484, erUendelig = false),
+                        TidslinjePeriode(periodeVerdi = 1054, lengde = 1461, erUendelig = false),
+                        TidslinjePeriode(periodeVerdi = 1083, lengde = 122, erUendelig = false),
+                        TidslinjePeriode(periodeVerdi = 1310, lengde = 184, erUendelig = false),
+                        TidslinjePeriode(periodeVerdi = 1510, lengde = 244, erUendelig = false),
+                        TidslinjePeriode(periodeVerdi = 1766, lengde = 1000000000, erUendelig = true),
+                    ),
+            )
+        val fom = LocalDate.of(2025, 1, 6)
+
+        val klippet = tidslinje.klipp(startTidspunkt = fom)
+
+        assertTrue(klippet.innhold.last().erUendelig)
     }
 }


### PR DESCRIPTION
Når fra og med-dato på en tidslinje klippes, blir i noen tilfeller siste periode i tidslinjen kortere enn `INF` (definisjonen på uendelighet). Tidslinjer der fom klippes skal beholde uendelighet. Løser problemet ved å sjekke om tidslinjen er uendelig og at `sluttidspunkt` er større eller lik `kalkulertSluttidspunkt`