### PR TITLE
Robustgjøring av valutakurs

### DIFF
--- a/valutakurs-klient/README.md
+++ b/valutakurs-klient/README.md
@@ -1,0 +1,22 @@
+# valutakurs-klient
+Klient for å hente valutakurser fra European Central Bank (ECB)
+## Dokumentasjonen for ECB
+https://data.ecb.europa.eu/help/api/overview
+
+### Content negotiation
+Tjenesten bruker content negotiation 
+`application/vnd.sdmx.genericdata+xml;version=2.1`
+for å hente valutakurser.
+
+Man kan få oversikt over content negotiation som støttes på:
+https://data.ecb.europa.eu/help/api/content-negotiation
+
+Man bør jevnlig sjekke om det er nye versjoner av content negotiation som støttes og evt oppgradere til nyeste versjon.
+
+### Fremtidige forbedringer
+Bytte til å bruke en content negotiation basert på JSON.
+### Test
+Det er en integrasjonstest som henter valutakurser fra ECB. Denne heter `ValutakursIntegrasjonTest` og ligger i `src/test/java/no/nav/familie/valutakurs/ValutakursIntegrasjonTest.kt`
+
+Testen kan ikke default med bygg mem kan kjøre med profilen `integration`:  
+`mvn clean test -Pintegration`

--- a/valutakurs-klient/pom.xml
+++ b/valutakurs-klient/pom.xml
@@ -63,6 +63,41 @@
 
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludedGroups>integration</excludedGroups>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>integration</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <groups>integration</groups>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+    </profiles>
+
     <build>
         <plugins>
             <plugin>

--- a/valutakurs-klient/src/main/java/no/nav/familie/valutakurs/config/ValutakursRestClientConfig.kt
+++ b/valutakurs-klient/src/main/java/no/nav/familie/valutakurs/config/ValutakursRestClientConfig.kt
@@ -3,6 +3,7 @@ package no.nav.familie.valutakurs.config
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.dataformat.xml.XmlMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import no.nav.familie.valutakurs.ValutakursRestClient.Companion.APPLICATION_CONTEXT_SDMX_ML_2_1_GENERIC_DATA
 import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -28,7 +29,7 @@ class ValutakursRestClientConfig {
             MappingJackson2HttpMessageConverter(xmlMapper()).apply {
                 supportedMediaTypes =
                     listOf(
-                        MediaType.parseMediaType("application/vnd.sdmx.genericdata+xml;version=2.1"),
+                        MediaType.parseMediaType(APPLICATION_CONTEXT_SDMX_ML_2_1_GENERIC_DATA),
                         MediaType.parseMediaType("application/octet-stream"),
                     )
             }

--- a/valutakurs-klient/src/test/java/no/nav/familie/valutakurs/ValutakursIntegrasjonTest.kt
+++ b/valutakurs-klient/src/test/java/no/nav/familie/valutakurs/ValutakursIntegrasjonTest.kt
@@ -1,0 +1,32 @@
+package no.nav.familie.valutakurs
+
+import no.nav.familie.valutakurs.config.ValutakursRestClientConfig
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@Tag("integration")
+class ValutakursIntegrasjonTest {
+    @Test
+    fun `Test mot ECB at vi får hentet valutakurs`() {
+        val kursdato = LocalDate.of(2025, 3, 13)
+        val config = ValutakursRestClientConfig()
+
+        val kurser =
+            ValutakursRestClient(
+                restOperations = config.xmlRestTemplate(),
+                ecbApiUrl = "https://data-api.ecb.europa.eu/service/data/EXR/",
+            ).hentValutakurs(
+                frequency = Frequency.Daily,
+                currencies = listOf("NOK"),
+                exchangeRateDate = kursdato,
+            )
+
+        assertEquals(1, kurser.size)
+        assertEquals(kursdato, kurser.first().date)
+        assertEquals("NOK", kurser.first().currency)
+        assertEquals(BigDecimal.valueOf(11.5975), kurser.first().exchangeRate)
+    }
+}


### PR DESCRIPTION
NAV-24457

Robustgjøring av klienten. 
- Spør etter en spesifikk versjon av kontrakten for at tjenesten ikke skal plutselig endre seg. 
- Lagt til støtte for integrasjonstester og konfigurer Maven-profiler for testkjøring