### PR TITLE
NAV-24606: Fikser bug relatert til hjelpemetoden `trim` for tidslinjer

### DIFF
--- a/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/TidslinjeUtvidelser.kt
+++ b/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/TidslinjeUtvidelser.kt
@@ -83,18 +83,11 @@ fun <T> Tidslinje<T>.trim(vararg periodeVerdier: PeriodeVerdi<T>): Tidslinje<T> 
         .medTittel(this.tittel)
 
 fun <T> Tidslinje<T>.trimVenstre(vararg periodeVerdier: PeriodeVerdi<T>): Tidslinje<T> {
-    val perioder = ArrayList(this.innhold)
-    var startsTidspunkt = this.startsTidspunkt
+    val dagerÅForskyveStartsTidspunkt = this.innhold.takeWhile { it.periodeVerdi in periodeVerdier }.sumOf { it.lengde }
 
-    for (periode in this.innhold) {
-        if (periodeVerdier.contains(periode.periodeVerdi)) {
-            startsTidspunkt = startsTidspunkt.plus(periode.lengde.toLong(), mapper[this.tidsEnhet])
-            perioder.remove(periode)
-        } else {
-            break
-        }
-    }
-    val resultat = Tidslinje(startsTidspunkt, perioder, this.tidsEnhet)
+    val perioder = this.innhold.dropWhile { it.periodeVerdi in periodeVerdier }
+
+    val resultat = Tidslinje(this.startsTidspunkt.plus(dagerÅForskyveStartsTidspunkt, mapper[this.tidsEnhet]), perioder, this.tidsEnhet)
 
     this.foreldre.forEach {
         if (!resultat.foreldre.contains(it)) {
@@ -106,15 +99,7 @@ fun <T> Tidslinje<T>.trimVenstre(vararg periodeVerdier: PeriodeVerdi<T>): Tidsli
 }
 
 fun <T> Tidslinje<T>.trimHøyre(vararg periodeVerdier: PeriodeVerdi<T>): Tidslinje<T> {
-    val perioder = ArrayList(this.innhold)
-
-    for (periode in this.innhold.reversed()) {
-        if (periodeVerdier.contains(periode.periodeVerdi)) {
-            perioder.remove(periode)
-        } else {
-            break
-        }
-    }
+    val perioder = this.innhold.dropLastWhile { it.periodeVerdi in periodeVerdier }
 
     val resultat = Tidslinje(this.startsTidspunkt, perioder, this.tidsEnhet)
 

--- a/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/TidslinjeUtvidelser.kt
+++ b/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/TidslinjeUtvidelser.kt
@@ -83,11 +83,13 @@ fun <T> Tidslinje<T>.trim(vararg periodeVerdier: PeriodeVerdi<T>): Tidslinje<T> 
         .medTittel(this.tittel)
 
 fun <T> Tidslinje<T>.trimVenstre(vararg periodeVerdier: PeriodeVerdi<T>): Tidslinje<T> {
-    val dagerÅForskyveStartsTidspunkt = this.innhold.takeWhile { it.periodeVerdi in periodeVerdier }.sumOf { it.lengde }
+    val antallTidsenheterÅForskyve = this.innhold.takeWhile { it.periodeVerdi in periodeVerdier }.sumOf { it.lengde }
+    val nyttStarsTidspunkt = this.startsTidspunkt.plus(antallTidsenheterÅForskyve, mapper[this.tidsEnhet])
 
     val perioder = this.innhold.dropWhile { it.periodeVerdi in periodeVerdier }
 
-    val resultat = Tidslinje(this.startsTidspunkt.plus(dagerÅForskyveStartsTidspunkt, mapper[this.tidsEnhet]), perioder, this.tidsEnhet)
+    val resultat =
+        Tidslinje(nyttStarsTidspunkt, perioder, this.tidsEnhet)
 
     this.foreldre.forEach {
         if (!resultat.foreldre.contains(it)) {
@@ -407,11 +409,11 @@ fun <V> Collection<Periode<V>>.verdiPåTidspunkt(tidspunkt: LocalDate): V? = thi
 fun <T> Tidslinje<T>.tilTidslinjePerioderMedDato(): List<TidslinjePeriodeMedDato<T>> {
     val (tidslinjePeriodeMedLocalDateListe, _) =
         this.innhold.fold(Pair(emptyList<TidslinjePeriodeMedDato<T>>(), 0L)) {
-            (
-                tidslinjePeriodeMedLocalDateListe: List<TidslinjePeriodeMedDato<T>>,
-                tidFraStarttidspunktFom: Long,
-            ),
-            tidslinjePeriode,
+                (
+                    tidslinjePeriodeMedLocalDateListe: List<TidslinjePeriodeMedDato<T>>,
+                    tidFraStarttidspunktFom: Long,
+                ),
+                tidslinjePeriode,
             ->
             val tidFraStarttidspunktTilNesteFom = tidFraStarttidspunktFom + tidslinjePeriode.lengde
 

--- a/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/TidslinjeUtvidelser.kt
+++ b/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/TidslinjeUtvidelser.kt
@@ -84,12 +84,12 @@ fun <T> Tidslinje<T>.trim(vararg periodeVerdier: PeriodeVerdi<T>): Tidslinje<T> 
 
 fun <T> Tidslinje<T>.trimVenstre(vararg periodeVerdier: PeriodeVerdi<T>): Tidslinje<T> {
     val antallTidsenheterÅForskyve = this.innhold.takeWhile { it.periodeVerdi in periodeVerdier }.sumOf { it.lengde }
-    val nyttStarsTidspunkt = this.startsTidspunkt.plus(antallTidsenheterÅForskyve, mapper[this.tidsEnhet])
+    val nyttStartsTidspunkt = this.startsTidspunkt.plus(antallTidsenheterÅForskyve, mapper[this.tidsEnhet])
 
     val perioder = this.innhold.dropWhile { it.periodeVerdi in periodeVerdier }
 
     val resultat =
-        Tidslinje(nyttStarsTidspunkt, perioder, this.tidsEnhet)
+        Tidslinje(nyttStartsTidspunkt, perioder, this.tidsEnhet)
 
     this.foreldre.forEach {
         if (!resultat.foreldre.contains(it)) {

--- a/tidslinje/src/test/kotlin/no/nav/familie/tidslinje/utvidelser/TidslinjeUtvidelserTest.kt
+++ b/tidslinje/src/test/kotlin/no/nav/familie/tidslinje/utvidelser/TidslinjeUtvidelserTest.kt
@@ -1,0 +1,73 @@
+package no.nav.familie.tidslinje.utvidelser
+
+import no.nav.familie.tidslinje.Null
+import no.nav.familie.tidslinje.Periode
+import no.nav.familie.tidslinje.Tidslinje
+import no.nav.familie.tidslinje.tilTidslinje
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.YearMonth
+
+class TidslinjeUtvidelserTest {
+    @Nested
+    inner class Trim {
+        val perioderMedNullFørstSistOgIMidten: List<Periode<Int?>> =
+            listOf(
+                Periode(null, YearMonth.of(2025, 1).atDay(1), YearMonth.of(2025, 1).atEndOfMonth()),
+                Periode(2, YearMonth.of(2025, 2).atDay(1), YearMonth.of(2025, 2).atEndOfMonth()),
+                Periode(3, YearMonth.of(2025, 3).atDay(1), YearMonth.of(2025, 3).atEndOfMonth()),
+                Periode(null, YearMonth.of(2025, 4).atDay(1), YearMonth.of(2025, 4).atEndOfMonth()),
+                Periode(2, YearMonth.of(2025, 5).atDay(1), YearMonth.of(2025, 5).atEndOfMonth()),
+                Periode(null, YearMonth.of(2025, 6).atDay(1), YearMonth.of(2025, 6).atEndOfMonth()),
+            )
+
+        @Test
+        fun `skal fjerne perioder med periodeVerdi lik Null() i starten og slutten av tidslinja`() {
+            // Arrange
+            val forventedePerioder = perioderMedNullFørstSistOgIMidten.subList(1, 5)
+            val tidslinje: Tidslinje<Int?> = perioderMedNullFørstSistOgIMidten.tilTidslinje()
+
+            // Act
+            val trimmetTidslinje = tidslinje.trim(Null())
+
+            // Assert
+            assertEquals(4, trimmetTidslinje.innhold.size)
+            assertEquals(forventedePerioder, trimmetTidslinje.tilPerioder())
+        }
+
+        @Nested
+        inner class TrimVenstre {
+            @Test
+            fun `skal fjerne perioder med periodeVerdi lik Null() i starten av tidslinja`() {
+                // Arrange
+                val forventedePerioder = perioderMedNullFørstSistOgIMidten.subList(1, 6)
+                val tidslinje: Tidslinje<Int?> = perioderMedNullFørstSistOgIMidten.tilTidslinje()
+
+                // Act
+                val trimmetTidslinje = tidslinje.trimVenstre(Null())
+
+                // Assert
+                assertEquals(5, trimmetTidslinje.innhold.size)
+                assertEquals(forventedePerioder, trimmetTidslinje.tilPerioder())
+            }
+        }
+
+        @Nested
+        inner class TrimHøyre {
+            @Test
+            fun `skal fjerne perioder med periodeVerdi lik Null() i slutten av tidslinja`() {
+                // Arrange
+                val forventedePerioder = perioderMedNullFørstSistOgIMidten.subList(0, 5)
+                val tidslinje: Tidslinje<Int?> = perioderMedNullFørstSistOgIMidten.tilTidslinje()
+
+                // Act
+                val trimmetTidslinje = tidslinje.trimHøyre(Null())
+
+                // Assert
+                assertEquals(5, trimmetTidslinje.innhold.size)
+                assertEquals(forventedePerioder, trimmetTidslinje.tilPerioder())
+            }
+        }
+    }
+}


### PR DESCRIPTION
I metodene `trimVenstre()` og `trimHøyre()` looper vi over alle perioder og identifiserer alle de første eller siste elementene som matcher innsendt `periodeVerdi`. Periodene som matcher forsøker vi å fjerne ved hjelp av `perioder.remove(periode)`, som fjerner første matchende periode fra lista. Dette fungerer for `trimVenstre`, men når vi kjører `trimHøyre` kan man ende opp med å fjerne et element som ikke ligger sist i lista dersom det finnes et element som kommer tidligere i lista som matcher innsendt `periodeVerdi`.

Skriver her om til å bruke henholdsvis `dropWhile` for `trimVenstre` og `dropLastWhile` for `trimHøyre` for å sørge for at vi ikke ender opp med å fjerne andre elementer enn de første og siste som matcher innsendt `periodeVerdi`.