### PR TITLE
extention-metode for å gjøre om perioder med null-lister til tomme liste

### DIFF
--- a/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/TidslinjeUtvidelser.kt
+++ b/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/TidslinjeUtvidelser.kt
@@ -466,3 +466,5 @@ fun <T> Tidslinje<T>.slåSammenLikePerioder(): Tidslinje<T> =
         perioder = this.innhold.slåSammenLike(),
         tidsEnhet = this.tidsEnhet,
     )
+
+fun <T> Periode<List<T>?>.byttUtNullListeMedTomListe(): Periode<List<T>> = this.copy(verdi = this.verdi.orEmpty()) as Periode<List<T>>

--- a/tidslinje/src/test/kotlin/no/nav/familie/tidslinje/utvidelser/ByttUtNullListeMedTomListeTest.kt
+++ b/tidslinje/src/test/kotlin/no/nav/familie/tidslinje/utvidelser/ByttUtNullListeMedTomListeTest.kt
@@ -1,0 +1,35 @@
+package no.nav.familie.tidslinje.utvidelser
+
+import no.nav.familie.tidslinje.Periode
+import no.nav.familie.tidslinje.tilTidslinje
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class ByttUtNullListeMedTomListeTest {
+
+    private val femÅrSiden = LocalDate.now().minusYears(5)
+    private val fireÅrOgÉnDagSiden = LocalDate.now().minusYears(4).minusDays(1)
+    private val fireÅrSiden = LocalDate.now().minusYears(4)
+    private val treÅrOgÉnDagSiden = LocalDate.now().minusYears(3).minusDays(1)
+    private val treÅrSiden = LocalDate.now().minusYears(3)
+    private val nå = LocalDate.now()
+
+    @Test
+    fun byttUtNullListeMedTomListe() {
+        // Arrange
+        val tidslinjeMedNullListe = listOf<Periode<List<String>?>>(
+            Periode(listOf("a"), femÅrSiden, fireÅrOgÉnDagSiden),
+            Periode(null, fireÅrSiden, treÅrOgÉnDagSiden),
+            Periode(listOf("b"), treÅrSiden, nå)
+        ).tilTidslinje()
+
+        // Act
+        val tidslinjeMedTomListeIstedetForNull = tidslinjeMedNullListe.tilPerioder().map { it.byttUtNullListeMedTomListe() }
+
+        // Assert
+        Assertions.assertNotNull(tidslinjeMedTomListeIstedetForNull.find { it.fom == fireÅrSiden }?.verdi)
+        Assertions.assertEquals(emptyList<String>(), tidslinjeMedTomListeIstedetForNull.find { it.fom == fireÅrSiden }?.verdi)
+    }
+
+}


### PR DESCRIPTION
Når man bruker metoder som fun <T> Tidslinje<T>.tilPerioder(): List<Periode<T?>>  der verdien er en liste er det irriterende at man får ut null-verdier i stedet for tomme lister. 

Legger derfor til en metode som mapper om null-verdiene til tomme lister. 