### PR TITLE
feat(sikkerhet): introduser TokenContext-abstraksjon

### DIFF
--- a/http-client/README.md
+++ b/http-client/README.md
@@ -29,7 +29,7 @@ Legg til avhengigheten i `pom.xml`:
 
 ## Krav: TokenContext-implementasjon
 
-`BearerTokenClientInterceptor` bruker `TokenContextHolder` for å avgjøre om en forespørsel kommer fra et system (ingen innlogget bruker) eller en bruker (on-behalf-of). Uten en konfigurert `TokenContext`-implementasjon kaster interceptoren en `TokenContextConfigurationException` ved oppstart.
+`BearerTokenClientInterceptor` bruker `TokenContextHolder` for å avgjøre om en forespørsel kommer fra et system (ingen innlogget bruker) eller en bruker (on-behalf-of). Uten en konfigurert `TokenContext`-implementasjon kaster interceptoren en `TokenContextKonfigurasjonException` ved oppstart.
 
 Legg til én av følgende avhengigheter og importer tilhørende konfigurasjonsklasse:
 

--- a/http-client/README.md
+++ b/http-client/README.md
@@ -1,0 +1,107 @@
+# http-client
+
+HTTP-klientbibliotek basert på Spring `RestTemplate`. Tilbyr abstrakte baseklasser for REST- og SOAP-klienter, samt interceptorer for Bearer-token-autentisering mot interne Nav-tjenester.
+
+## Innhold
+
+| Klasse | Beskrivelse |
+|--------|-------------|
+| `AbstractRestClient` | Baseklasse for typede REST-klienter med feilhåndtering og logging |
+| `AbstractPingableRestClient` | Utvider `AbstractRestClient` med helsesjekk (`/ping`) |
+| `BearerTokenClientInterceptor` | Henter access token automatisk og setter `Authorization: Bearer`-header |
+| `BearerTokenClientCredentialsClientInterceptor` | Som over, men tvinger client credentials grant |
+| `BearerTokenOnBehalfOfClientInterceptor` | Som over, men tvinger on-behalf-of (JWT bearer) grant |
+| `BearerTokenExchangeClientInterceptor` | Som over, men tvinger token exchange grant |
+| `ConsumerIdClientInterceptor` | Setter `Nav-Consumer-Id`-header |
+| `MdcValuesPropagatingClientInterceptor` | Propagerer MDC-verdier (correlation ID o.l.) til utgående kall |
+
+## Kom i gang
+
+Legg til avhengigheten i `pom.xml`:
+
+```xml
+<dependency>
+    <groupId>no.nav.familie.felles</groupId>
+    <artifactId>http-client</artifactId>
+    <version>${familie-felles.version}</version>
+</dependency>
+```
+
+## Krav: TokenContext-implementasjon
+
+`BearerTokenClientInterceptor` bruker `TokenContextHolder` for å avgjøre om en forespørsel kommer fra et system (ingen innlogget bruker) eller en bruker (on-behalf-of). Uten en konfigurert `TokenContext`-implementasjon kaster interceptoren en `TokenContextConfigurationException` ved oppstart.
+
+Legg til én av følgende avhengigheter og importer tilhørende konfigurasjonsklasse:
+
+**Spring Security OAuth2 Resource Server**:
+
+```xml
+<dependency>
+    <groupId>no.nav.familie.felles</groupId>
+    <artifactId>sikkerhet-spring-security</artifactId>
+    <version>${familie-felles.version}</version>
+</dependency>
+```
+
+```kotlin
+@Import(FamilieFellesSpringSecurityKonfigurasjon::class)
+@SpringBootApplication
+class MinApp
+```
+
+**Nav token-support**:
+
+```xml
+<dependency>
+    <groupId>no.nav.familie.felles</groupId>
+    <artifactId>sikkerhet-token-support</artifactId>
+    <version>${familie-felles.version}</version>
+</dependency>
+```
+
+```kotlin
+@Import(FamilieFellesNavTokenSupportKonfigurasjon::class)
+@SpringBootApplication
+class MinApp
+```
+
+> Importer kun én av disse. Spring kaster feil ved oppstart dersom begge importeres samtidig.
+
+## Bruk
+
+### Implementere en REST-klient
+
+```kotlin
+@Service
+class MinTjenesteKlient(
+    restTemplate: RestTemplate,
+    @Value("\${min-tjeneste.url}") baseUrl: String,
+) : AbstractPingableRestClient(restTemplate, "min-tjeneste") {
+
+    private val uri = URI.create(baseUrl)
+
+    fun hentData(id: String): MinData =
+        getForEntity(uri.resolve("/api/data/$id"), MinData::class.java)
+}
+```
+
+### Sette opp RestTemplate med interceptorer
+
+```kotlin
+@Import(
+    BearerTokenClientInterceptor::class,
+    ConsumerIdClientInterceptor::class
+)
+class RestTemplateConfig {
+    @Bean
+    fun restTemplate(
+        bearerTokenClientInterceptor: BearerTokenClientInterceptor,
+        consumerIdClientInterceptor: ConsumerIdClientInterceptor,
+    ): RestTemplate =
+        RestTemplateBuilder()
+            .interceptors(
+                bearerTokenClientInterceptor,
+                consumerIdClientInterceptor,
+            ).build()
+}
+```

--- a/http-client/pom.xml
+++ b/http-client/pom.xml
@@ -102,6 +102,15 @@
             <artifactId>spring-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-test</artifactId>
             <scope>test</scope>

--- a/http-client/pom.xml
+++ b/http-client/pom.xml
@@ -56,6 +56,13 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>no.nav.familie.felles</groupId>
+            <artifactId>sikkerhet</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>no.nav.familie.kontrakter</groupId>
             <artifactId>felles</artifactId>
         </dependency>
@@ -109,11 +116,6 @@
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-test</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/http-client/src/main/java/no/nav/familie/http/interceptor/BearerTokenClientInterceptor.kt
+++ b/http-client/src/main/java/no/nav/familie/http/interceptor/BearerTokenClientInterceptor.kt
@@ -2,11 +2,12 @@ package no.nav.familie.http.interceptor
 
 import com.nimbusds.oauth2.sdk.GrantType
 import no.nav.familie.http.sts.StsRestClient
+import no.nav.familie.sikkerhet.context.TokenContextConfigurationException
+import no.nav.familie.sikkerhet.context.TokenContextHolder
 import no.nav.security.token.support.client.core.ClientProperties
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
 import no.nav.security.token.support.client.spring.ClientConfigurationProperties
 import no.nav.security.token.support.core.exceptions.JwtTokenValidatorException
-import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
 import org.springframework.http.HttpRequest
 import org.springframework.http.client.ClientHttpRequestExecution
 import org.springframework.http.client.ClientHttpRequestInterceptor
@@ -187,13 +188,12 @@ private fun clientPropertiesForGrantType(
 
 private fun clientCredentialOrJwtBearer() = if (erSystembruker()) GrantType.CLIENT_CREDENTIALS else GrantType.JWT_BEARER
 
-private fun erSystembruker(): Boolean {
-    return try {
-        val preferredUsername =
-            SpringTokenValidationContextHolder().getTokenValidationContext().getClaims("azuread").get("preferred_username")
-        return preferredUsername == null
+private fun erSystembruker(): Boolean =
+    try {
+        TokenContextHolder.getClaimAsString("preferred_username") == null
+    } catch (e: TokenContextConfigurationException) {
+        throw e // Konfigurasjonsfeil skal ikke catches
     } catch (e: Throwable) {
         // Ingen request context. Skjer ved kall som har opphav i kjørende applikasjon. Ping etc.
         true
     }
-}

--- a/http-client/src/main/java/no/nav/familie/http/interceptor/BearerTokenClientInterceptor.kt
+++ b/http-client/src/main/java/no/nav/familie/http/interceptor/BearerTokenClientInterceptor.kt
@@ -2,8 +2,8 @@ package no.nav.familie.http.interceptor
 
 import com.nimbusds.oauth2.sdk.GrantType
 import no.nav.familie.http.sts.StsRestClient
-import no.nav.familie.sikkerhet.context.TokenContextConfigurationException
 import no.nav.familie.sikkerhet.context.TokenContextHolder
+import no.nav.familie.sikkerhet.context.TokenContextKonfigurasjonException
 import no.nav.security.token.support.client.core.ClientProperties
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
 import no.nav.security.token.support.client.spring.ClientConfigurationProperties
@@ -191,7 +191,7 @@ private fun clientCredentialOrJwtBearer() = if (erSystembruker()) GrantType.CLIE
 private fun erSystembruker(): Boolean =
     try {
         TokenContextHolder.getClaimAsString("preferred_username") == null
-    } catch (e: TokenContextConfigurationException) {
+    } catch (e: TokenContextKonfigurasjonException) {
         throw e // Konfigurasjonsfeil skal ikke catches
     } catch (e: Throwable) {
         // Ingen request context. Skjer ved kall som har opphav i kjørende applikasjon. Ping etc.

--- a/http-client/src/test/java/no/nav/familie/http/interceptor/BearerTokenClientInterceptorTest.kt
+++ b/http-client/src/test/java/no/nav/familie/http/interceptor/BearerTokenClientInterceptorTest.kt
@@ -4,7 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.sikkerhet.context.TokenContext
-import no.nav.familie.sikkerhet.context.TokenContextConfigurationException
+import no.nav.familie.sikkerhet.context.TokenContextKonfigurasjonException
 import no.nav.familie.sikkerhet.context.TokenContextTestHelper
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
 import org.junit.jupiter.api.AfterEach
@@ -63,14 +63,14 @@ class BearerTokenClientInterceptorTest {
     }
 
     @Test
-    fun `erSystembruker kaster TokenContextConfigurationException videre når TokenContextHolder ikke er konfigurert`() {
+    fun `erSystembruker kaster TokenContextKonfigurasjonException videre når TokenContextHolder ikke er konfigurert`() {
         TokenContextTestHelper.clearContext()
 
         val req = mockk<HttpRequest>(relaxed = true, relaxUnitFun = true)
         every { req.uri } returns (URI("http://firstResource.no"))
         val execution = mockk<ClientHttpRequestExecution>(relaxed = true)
 
-        assertThrows(TokenContextConfigurationException::class.java) {
+        assertThrows(TokenContextKonfigurasjonException::class.java) {
             bearerTokenClientInterceptor.intercept(req, ByteArray(0), execution)
         }
     }

--- a/http-client/src/test/java/no/nav/familie/http/interceptor/BearerTokenClientInterceptorTest.kt
+++ b/http-client/src/test/java/no/nav/familie/http/interceptor/BearerTokenClientInterceptorTest.kt
@@ -3,26 +3,28 @@ package no.nav.familie.http.interceptor
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.familie.sikkerhet.context.TokenContext
+import no.nav.familie.sikkerhet.context.TokenContextConfigurationException
+import no.nav.familie.sikkerhet.context.TokenContextHolder
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
-import no.nav.security.token.support.core.context.TokenValidationContext
-import no.nav.security.token.support.core.jwt.JwtTokenClaims
-import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpRequest
 import org.springframework.http.client.ClientHttpRequestExecution
-import org.springframework.web.context.request.RequestAttributes
-import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.test.util.ReflectionTestUtils
 import java.net.URI
 
 class BearerTokenClientInterceptorTest {
     private lateinit var bearerTokenClientInterceptor: BearerTokenClientInterceptor
 
     private val oAuth2AccessTokenService = mockk<OAuth2AccessTokenService>(relaxed = true)
+    private val tokenContext = mockk<TokenContext>(relaxed = true)
 
     @BeforeEach
     fun setup() {
+        ReflectionTestUtils.setField(TokenContextHolder, "context", tokenContext)
         bearerTokenClientInterceptor =
             BearerTokenClientInterceptor(
                 oAuth2AccessTokenService,
@@ -31,12 +33,14 @@ class BearerTokenClientInterceptorTest {
     }
 
     @AfterEach
-    internal fun tearDown() {
-        clearBrukerContext()
+    fun tearDown() {
+        ReflectionTestUtils.setField(TokenContextHolder, "context", null)
     }
 
     @Test
     fun `intercept bruker grant type client credentials når det ikke er noen request context`() {
+        every { tokenContext.getClaimAsString("preferred_username", "azuread") } returns null
+
         val req = mockk<HttpRequest>(relaxed = true, relaxUnitFun = true)
         every { req.uri } returns (URI("http://firstResource.no"))
         val execution = mockk<ClientHttpRequestExecution>(relaxed = true)
@@ -48,7 +52,7 @@ class BearerTokenClientInterceptorTest {
 
     @Test
     fun `intercept bruker grant type jwt token når det finnes saksbehandler context`() {
-        mockBrukerContext("saksbehandler")
+        every { tokenContext.getClaimAsString("preferred_username", "azuread") } returns "saksbehandler"
 
         val req = mockk<HttpRequest>(relaxed = true, relaxUnitFun = true)
         every { req.uri } returns (URI("http://firstResource.no"))
@@ -59,23 +63,16 @@ class BearerTokenClientInterceptorTest {
         verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration["2"]!!) }
     }
 
-    fun mockBrukerContext(preferredUsername: String) {
-        val tokenValidationContext = mockk<TokenValidationContext>()
-        val jwtTokenClaims = mockk<JwtTokenClaims>()
-        val requestAttributes = mockk<RequestAttributes>()
-        RequestContextHolder.setRequestAttributes(requestAttributes)
-        every {
-            requestAttributes.getAttribute(
-                SpringTokenValidationContextHolder::class.java.name,
-                RequestAttributes.SCOPE_REQUEST,
-            )
-        } returns tokenValidationContext
-        every { tokenValidationContext.getClaims("azuread") } returns jwtTokenClaims
-        every { jwtTokenClaims.get("preferred_username") } returns preferredUsername
-        every { jwtTokenClaims.get("NAVident") } returns preferredUsername
-    }
+    @Test
+    fun `erSystembruker kaster TokenContextConfigurationException videre når TokenContextHolder ikke er konfigurert`() {
+        ReflectionTestUtils.setField(TokenContextHolder, "context", null)
 
-    fun clearBrukerContext() {
-        RequestContextHolder.resetRequestAttributes()
+        val req = mockk<HttpRequest>(relaxed = true, relaxUnitFun = true)
+        every { req.uri } returns (URI("http://firstResource.no"))
+        val execution = mockk<ClientHttpRequestExecution>(relaxed = true)
+
+        assertThrows(TokenContextConfigurationException::class.java) {
+            bearerTokenClientInterceptor.intercept(req, ByteArray(0), execution)
+        }
     }
 }

--- a/http-client/src/test/java/no/nav/familie/http/interceptor/BearerTokenClientInterceptorTest.kt
+++ b/http-client/src/test/java/no/nav/familie/http/interceptor/BearerTokenClientInterceptorTest.kt
@@ -5,7 +5,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.sikkerhet.context.TokenContext
 import no.nav.familie.sikkerhet.context.TokenContextConfigurationException
-import no.nav.familie.sikkerhet.context.TokenContextHolder
+import no.nav.familie.sikkerhet.context.TokenContextTestHelper
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertThrows
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpRequest
 import org.springframework.http.client.ClientHttpRequestExecution
-import org.springframework.test.util.ReflectionTestUtils
 import java.net.URI
 
 class BearerTokenClientInterceptorTest {
@@ -24,7 +23,7 @@ class BearerTokenClientInterceptorTest {
 
     @BeforeEach
     fun setup() {
-        ReflectionTestUtils.setField(TokenContextHolder, "context", tokenContext)
+        TokenContextTestHelper.setContext(tokenContext)
         bearerTokenClientInterceptor =
             BearerTokenClientInterceptor(
                 oAuth2AccessTokenService,
@@ -34,7 +33,7 @@ class BearerTokenClientInterceptorTest {
 
     @AfterEach
     fun tearDown() {
-        ReflectionTestUtils.setField(TokenContextHolder, "context", null)
+        TokenContextTestHelper.clearContext()
     }
 
     @Test
@@ -65,7 +64,7 @@ class BearerTokenClientInterceptorTest {
 
     @Test
     fun `erSystembruker kaster TokenContextConfigurationException videre når TokenContextHolder ikke er konfigurert`() {
-        ReflectionTestUtils.setField(TokenContextHolder, "context", null)
+        TokenContextTestHelper.clearContext()
 
         val req = mockk<HttpRequest>(relaxed = true, relaxUnitFun = true)
         every { req.uri } returns (URI("http://firstResource.no"))

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,8 @@
         <module>http-client</module>
         <module>rest-klient</module>
         <module>sikkerhet</module>
+        <module>sikkerhet-token-support</module>
+        <module>sikkerhet-spring-security</module>
         <module>leader</module>
         <module>modell</module>
         <module>util</module>
@@ -148,6 +150,16 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>sikkerhet</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>sikkerhet-spring-security</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>sikkerhet-token-support</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <url>https://github.com/navikt/familie-felles</url>
 
     <properties>
-        <revision>4.0</revision>
+        <revision>4.1</revision>
         <sha1/>
         <changelist>-SNAPSHOT</changelist>
         <java.version>21</java.version>

--- a/rest-klient/README.md
+++ b/rest-klient/README.md
@@ -29,7 +29,7 @@ Legg til avhengigheten i `pom.xml`:
 
 ## Krav: TokenContext-implementasjon
 
-`BearerTokenClientInterceptor` bruker `TokenContextHolder` for å avgjøre om en forespørsel kommer fra et system (ingen innlogget bruker) eller en bruker (on-behalf-of). Uten en konfigurert `TokenContext`-implementasjon kaster interceptoren en `TokenContextConfigurationException` ved oppstart.
+`BearerTokenClientInterceptor` bruker `TokenContextHolder` for å avgjøre om en forespørsel kommer fra et system (ingen innlogget bruker) eller en bruker (on-behalf-of). Uten en konfigurert `TokenContext`-implementasjon kaster interceptoren en `TokenContextKonfigurasjonException` ved oppstart.
 
 Legg til én av følgende avhengigheter og importer tilhørende konfigurasjonsklasse:
 

--- a/rest-klient/README.md
+++ b/rest-klient/README.md
@@ -1,0 +1,107 @@
+# rest-klient
+
+HTTP-klientbibliotek basert på Spring `RestTemplate`. Tilbyr abstrakte baseklasser for REST- og SOAP-klienter, samt interceptorer for Bearer-token-autentisering mot interne Nav-tjenester.
+
+## Innhold
+
+| Klasse | Beskrivelse |
+|--------|-------------|
+| `AbstractRestClient` | Baseklasse for typede REST-klienter med feilhåndtering og logging |
+| `AbstractPingableRestClient` | Utvider `AbstractRestClient` med helsesjekk (`/ping`) |
+| `BearerTokenClientInterceptor` | Henter access token automatisk og setter `Authorization: Bearer`-header |
+| `BearerTokenClientCredentialsClientInterceptor` | Som over, men tvinger client credentials grant |
+| `BearerTokenOnBehalfOfClientInterceptor` | Som over, men tvinger on-behalf-of (JWT bearer) grant |
+| `BearerTokenExchangeClientInterceptor` | Som over, men tvinger token exchange grant |
+| `ConsumerIdClientInterceptor` | Setter `Nav-Consumer-Id`-header |
+| `MdcValuesPropagatingClientInterceptor` | Propagerer MDC-verdier (correlation ID o.l.) til utgående kall |
+
+## Kom i gang
+
+Legg til avhengigheten i `pom.xml`:
+
+```xml
+<dependency>
+    <groupId>no.nav.familie.felles</groupId>
+    <artifactId>rest-klient</artifactId>
+    <version>${familie-felles.version}</version>
+</dependency>
+```
+
+## Krav: TokenContext-implementasjon
+
+`BearerTokenClientInterceptor` bruker `TokenContextHolder` for å avgjøre om en forespørsel kommer fra et system (ingen innlogget bruker) eller en bruker (on-behalf-of). Uten en konfigurert `TokenContext`-implementasjon kaster interceptoren en `TokenContextConfigurationException` ved oppstart.
+
+Legg til én av følgende avhengigheter og importer tilhørende konfigurasjonsklasse:
+
+**Spring Security OAuth2 Resource Server**:
+
+```xml
+<dependency>
+    <groupId>no.nav.familie.felles</groupId>
+    <artifactId>sikkerhet-spring-security</artifactId>
+    <version>${familie-felles.version}</version>
+</dependency>
+```
+
+```kotlin
+@Import(FamilieFellesSpringSecurityKonfigurasjon::class)
+@SpringBootApplication
+class MinApp
+```
+
+**Nav token-support**:
+
+```xml
+<dependency>
+    <groupId>no.nav.familie.felles</groupId>
+    <artifactId>sikkerhet-token-support</artifactId>
+    <version>${familie-felles.version}</version>
+</dependency>
+```
+
+```kotlin
+@Import(FamilieFellesNavTokenSupportKonfigurasjon::class)
+@SpringBootApplication
+class MinApp
+```
+
+> Importer kun én av disse. Spring kaster feil ved oppstart dersom begge importeres samtidig.
+
+## Bruk
+
+### Implementere en REST-klient
+
+```kotlin
+@Service
+class MinTjenesteKlient(
+    restTemplate: RestTemplate,
+    @Value("\${min-tjeneste.url}") baseUrl: String,
+) : AbstractPingableRestClient(restTemplate, "min-tjeneste") {
+
+    private val uri = URI.create(baseUrl)
+
+    fun hentData(id: String): MinData =
+        getForEntity(uri.resolve("/api/data/$id"), MinData::class.java)
+}
+```
+
+### Sette opp RestTemplate med interceptorer
+
+```kotlin
+@Import(
+    BearerTokenClientInterceptor::class,
+    ConsumerIdClientInterceptor::class
+)
+class RestTemplateConfig {
+    @Bean
+    fun restTemplate(
+        bearerTokenClientInterceptor: BearerTokenClientInterceptor,
+        consumerIdClientInterceptor: ConsumerIdClientInterceptor,
+    ): RestTemplate =
+        RestTemplateBuilder()
+            .interceptors(
+                bearerTokenClientInterceptor,
+                consumerIdClientInterceptor,
+            ).build()
+}
+```

--- a/rest-klient/pom.xml
+++ b/rest-klient/pom.xml
@@ -48,6 +48,13 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>no.nav.familie.felles</groupId>
+            <artifactId>sikkerhet</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>no.nav.familie.kontrakter</groupId>
             <artifactId>felles</artifactId>
             <version>4.0_20260203161501_d70fd23</version>
@@ -99,11 +106,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-test</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/rest-klient/src/main/java/no/nav/familie/restklient/interceptor/BearerTokenClientInterceptor.kt
+++ b/rest-klient/src/main/java/no/nav/familie/restklient/interceptor/BearerTokenClientInterceptor.kt
@@ -2,11 +2,12 @@ package no.nav.familie.restklient.interceptor
 
 import com.nimbusds.oauth2.sdk.GrantType
 import no.nav.familie.restklient.sts.StsRestClient
+import no.nav.familie.sikkerhet.context.TokenContextConfigurationException
+import no.nav.familie.sikkerhet.context.TokenContextHolder
 import no.nav.security.token.support.client.core.ClientProperties
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
 import no.nav.security.token.support.client.spring.ClientConfigurationProperties
 import no.nav.security.token.support.core.exceptions.JwtTokenValidatorException
-import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
 import org.springframework.http.HttpRequest
 import org.springframework.http.client.ClientHttpRequestExecution
 import org.springframework.http.client.ClientHttpRequestInterceptor
@@ -187,13 +188,12 @@ private fun clientPropertiesForGrantType(
 
 private fun clientCredentialOrJwtBearer() = if (erSystembruker()) GrantType.CLIENT_CREDENTIALS else GrantType.JWT_BEARER
 
-private fun erSystembruker(): Boolean {
-    return try {
-        val preferredUsername =
-            SpringTokenValidationContextHolder().getTokenValidationContext().getClaims("azuread").get("preferred_username")
-        return preferredUsername == null
+private fun erSystembruker(): Boolean =
+    try {
+        TokenContextHolder.getClaimAsString("preferred_username") == null
+    } catch (e: TokenContextConfigurationException) {
+        throw e // Konfigurasjonsfeil skal ikke catches
     } catch (e: Throwable) {
         // Ingen request context. Skjer ved kall som har opphav i kjørende applikasjon. Ping etc.
         true
     }
-}

--- a/rest-klient/src/main/java/no/nav/familie/restklient/interceptor/BearerTokenClientInterceptor.kt
+++ b/rest-klient/src/main/java/no/nav/familie/restklient/interceptor/BearerTokenClientInterceptor.kt
@@ -2,8 +2,8 @@ package no.nav.familie.restklient.interceptor
 
 import com.nimbusds.oauth2.sdk.GrantType
 import no.nav.familie.restklient.sts.StsRestClient
-import no.nav.familie.sikkerhet.context.TokenContextConfigurationException
 import no.nav.familie.sikkerhet.context.TokenContextHolder
+import no.nav.familie.sikkerhet.context.TokenContextKonfigurasjonException
 import no.nav.security.token.support.client.core.ClientProperties
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
 import no.nav.security.token.support.client.spring.ClientConfigurationProperties
@@ -191,7 +191,7 @@ private fun clientCredentialOrJwtBearer() = if (erSystembruker()) GrantType.CLIE
 private fun erSystembruker(): Boolean =
     try {
         TokenContextHolder.getClaimAsString("preferred_username") == null
-    } catch (e: TokenContextConfigurationException) {
+    } catch (e: TokenContextKonfigurasjonException) {
         throw e // Konfigurasjonsfeil skal ikke catches
     } catch (e: Throwable) {
         // Ingen request context. Skjer ved kall som har opphav i kjørende applikasjon. Ping etc.

--- a/rest-klient/src/test/java/no/nav/familie/restklient/interceptor/BearerTokenClientInterceptorTest.kt
+++ b/rest-klient/src/test/java/no/nav/familie/restklient/interceptor/BearerTokenClientInterceptorTest.kt
@@ -4,7 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.sikkerhet.context.TokenContext
-import no.nav.familie.sikkerhet.context.TokenContextConfigurationException
+import no.nav.familie.sikkerhet.context.TokenContextKonfigurasjonException
 import no.nav.familie.sikkerhet.context.TokenContextTestHelper
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
 import org.junit.jupiter.api.AfterEach
@@ -63,14 +63,14 @@ class BearerTokenClientInterceptorTest {
     }
 
     @Test
-    fun `erSystembruker kaster TokenContextConfigurationException videre når TokenContextHolder ikke er konfigurert`() {
+    fun `erSystembruker kaster TokenContextKonfigurasjonException videre når TokenContextHolder ikke er konfigurert`() {
         TokenContextTestHelper.clearContext()
 
         val req = mockk<HttpRequest>(relaxed = true, relaxUnitFun = true)
         every { req.uri } returns (URI("http://firstResource.no"))
         val execution = mockk<ClientHttpRequestExecution>(relaxed = true)
 
-        assertThrows(TokenContextConfigurationException::class.java) {
+        assertThrows(TokenContextKonfigurasjonException::class.java) {
             bearerTokenClientInterceptor.intercept(req, ByteArray(0), execution)
         }
     }

--- a/rest-klient/src/test/java/no/nav/familie/restklient/interceptor/BearerTokenClientInterceptorTest.kt
+++ b/rest-klient/src/test/java/no/nav/familie/restklient/interceptor/BearerTokenClientInterceptorTest.kt
@@ -5,7 +5,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.sikkerhet.context.TokenContext
 import no.nav.familie.sikkerhet.context.TokenContextConfigurationException
-import no.nav.familie.sikkerhet.context.TokenContextHolder
+import no.nav.familie.sikkerhet.context.TokenContextTestHelper
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertThrows
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpRequest
 import org.springframework.http.client.ClientHttpRequestExecution
-import org.springframework.test.util.ReflectionTestUtils
 import java.net.URI
 
 class BearerTokenClientInterceptorTest {
@@ -24,7 +23,7 @@ class BearerTokenClientInterceptorTest {
 
     @BeforeEach
     fun setup() {
-        ReflectionTestUtils.setField(TokenContextHolder, "context", tokenContext)
+        TokenContextTestHelper.setContext(tokenContext)
         bearerTokenClientInterceptor =
             BearerTokenClientInterceptor(
                 oAuth2AccessTokenService,
@@ -34,7 +33,7 @@ class BearerTokenClientInterceptorTest {
 
     @AfterEach
     fun tearDown() {
-        ReflectionTestUtils.setField(TokenContextHolder, "context", null)
+        TokenContextTestHelper.clearContext()
     }
 
     @Test
@@ -65,7 +64,7 @@ class BearerTokenClientInterceptorTest {
 
     @Test
     fun `erSystembruker kaster TokenContextConfigurationException videre når TokenContextHolder ikke er konfigurert`() {
-        ReflectionTestUtils.setField(TokenContextHolder, "context", null)
+        TokenContextTestHelper.clearContext()
 
         val req = mockk<HttpRequest>(relaxed = true, relaxUnitFun = true)
         every { req.uri } returns (URI("http://firstResource.no"))

--- a/rest-klient/src/test/java/no/nav/familie/restklient/interceptor/BearerTokenClientInterceptorTest.kt
+++ b/rest-klient/src/test/java/no/nav/familie/restklient/interceptor/BearerTokenClientInterceptorTest.kt
@@ -3,26 +3,28 @@ package no.nav.familie.restklient.interceptor
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.familie.sikkerhet.context.TokenContext
+import no.nav.familie.sikkerhet.context.TokenContextConfigurationException
+import no.nav.familie.sikkerhet.context.TokenContextHolder
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
-import no.nav.security.token.support.core.context.TokenValidationContext
-import no.nav.security.token.support.core.jwt.JwtTokenClaims
-import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpRequest
 import org.springframework.http.client.ClientHttpRequestExecution
-import org.springframework.web.context.request.RequestAttributes
-import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.test.util.ReflectionTestUtils
 import java.net.URI
 
 class BearerTokenClientInterceptorTest {
     private lateinit var bearerTokenClientInterceptor: BearerTokenClientInterceptor
 
     private val oAuth2AccessTokenService = mockk<OAuth2AccessTokenService>(relaxed = true)
+    private val tokenContext = mockk<TokenContext>(relaxed = true)
 
     @BeforeEach
     fun setup() {
+        ReflectionTestUtils.setField(TokenContextHolder, "context", tokenContext)
         bearerTokenClientInterceptor =
             BearerTokenClientInterceptor(
                 oAuth2AccessTokenService,
@@ -31,12 +33,14 @@ class BearerTokenClientInterceptorTest {
     }
 
     @AfterEach
-    internal fun tearDown() {
-        clearBrukerContext()
+    fun tearDown() {
+        ReflectionTestUtils.setField(TokenContextHolder, "context", null)
     }
 
     @Test
     fun `intercept bruker grant type client credentials når det ikke er noen request context`() {
+        every { tokenContext.getClaimAsString("preferred_username", "azuread") } returns null
+
         val req = mockk<HttpRequest>(relaxed = true, relaxUnitFun = true)
         every { req.uri } returns (URI("http://firstResource.no"))
         val execution = mockk<ClientHttpRequestExecution>(relaxed = true)
@@ -48,7 +52,7 @@ class BearerTokenClientInterceptorTest {
 
     @Test
     fun `intercept bruker grant type jwt token når det finnes saksbehandler context`() {
-        mockBrukerContext("saksbehandler")
+        every { tokenContext.getClaimAsString("preferred_username", "azuread") } returns "saksbehandler"
 
         val req = mockk<HttpRequest>(relaxed = true, relaxUnitFun = true)
         every { req.uri } returns (URI("http://firstResource.no"))
@@ -59,23 +63,16 @@ class BearerTokenClientInterceptorTest {
         verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration["2"]!!) }
     }
 
-    fun mockBrukerContext(preferredUsername: String) {
-        val tokenValidationContext = mockk<TokenValidationContext>()
-        val jwtTokenClaims = mockk<JwtTokenClaims>()
-        val requestAttributes = mockk<RequestAttributes>()
-        RequestContextHolder.setRequestAttributes(requestAttributes)
-        every {
-            requestAttributes.getAttribute(
-                SpringTokenValidationContextHolder::class.java.name,
-                RequestAttributes.SCOPE_REQUEST,
-            )
-        } returns tokenValidationContext
-        every { tokenValidationContext.getClaims("azuread") } returns jwtTokenClaims
-        every { jwtTokenClaims.get("preferred_username") } returns preferredUsername
-        every { jwtTokenClaims.get("NAVident") } returns preferredUsername
-    }
+    @Test
+    fun `erSystembruker kaster TokenContextConfigurationException videre når TokenContextHolder ikke er konfigurert`() {
+        ReflectionTestUtils.setField(TokenContextHolder, "context", null)
 
-    fun clearBrukerContext() {
-        RequestContextHolder.resetRequestAttributes()
+        val req = mockk<HttpRequest>(relaxed = true, relaxUnitFun = true)
+        every { req.uri } returns (URI("http://firstResource.no"))
+        val execution = mockk<ClientHttpRequestExecution>(relaxed = true)
+
+        assertThrows(TokenContextConfigurationException::class.java) {
+            bearerTokenClientInterceptor.intercept(req, ByteArray(0), execution)
+        }
     }
 }

--- a/sikkerhet-spring-security/README.md
+++ b/sikkerhet-spring-security/README.md
@@ -1,0 +1,53 @@
+# sikkerhet-spring-security
+
+`TokenContext`-implementasjon basert på **Spring Security OAuth2 Resource Server**.
+
+## Kom i gang
+
+Legg til avhengigheten i `pom.xml`:
+
+```xml
+<dependency>
+    <groupId>no.nav.familie.felles</groupId>
+    <artifactId>sikkerhet-spring-security</artifactId>
+    <version>${familie-felles.version}</version>
+</dependency>
+```
+
+Importer konfigurasjonsklassen i applikasjonens hovedklasse eller en `@Configuration`-klasse:
+
+```kotlin
+@Import(FamilieFellesSpringSecurityKonfigurasjon::class)
+@SpringBootApplication
+class MinApp
+```
+
+Dette registrerer `SpringSecurityTokenContext` som aktiv `TokenContext`-implementasjon.
+
+## Issuermapping
+
+`SpringSecurityTokenContext` identifiserer issueren via `iss`-claimet i JWT-en. Resten av biblioteket bruker kortnavn som `"azuread"` og `"tokenx"`, ikke fulle issuer-URLer.
+
+På NAIS bygges mappingen automatisk fra miljøvariablene som NAIS alltid injiserer:
+
+| Miljøvariabel | Kortnavn |
+|---|---|
+| `AZURE_OPENID_CONFIG_ISSUER` | `"azuread"` |
+| `TOKEN_X_ISSUER` | `"tokenx"` |
+
+Du trenger ikke konfigurere noe ekstra. I ikke-NAIS-miljøer (f.eks. lokalt uten disse variablene) brukes full issuer-URL i kall til `TokenContextHolder`.
+
+## Bruk
+
+```kotlin
+val saksbehandler = TokenContextHolder.getClaimAsString("NAVident")
+val harAzureToken = TokenContextHolder.hasTokenFor("azuread")
+val bearerToken = TokenContextHolder.getBearerToken("azuread")
+```
+
+## Relaterte moduler
+
+| Modul | Beskrivelse |
+|-------|-------------|
+| `sikkerhet` | Felles API – `TokenContext`-grensesnitt og `TokenContextHolder` |
+| `sikkerhet-token-support` | Alternativ implementasjon basert på Nav token-support |

--- a/sikkerhet-spring-security/pom.xml
+++ b/sikkerhet-spring-security/pom.xml
@@ -10,31 +10,26 @@
         <version>${revision}${sha1}${changelist}</version>
     </parent>
 
-    <artifactId>sikkerhet</artifactId>
+    <artifactId>sikkerhet-spring-security</artifactId>
     <version>${revision}${sha1}${changelist}</version>
-    <name>Felles - Sikkerhet</name>
-    <description>Small lib for JWT operations</description>
+    <name>Felles - Sikkerhet Spring Security</name>
+    <description>TokenContext-implementasjon basert på Spring Security OAuth2 Resource Server</description>
     <packaging>jar</packaging>
 
     <dependencies>
         <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib</artifactId>
+            <groupId>no.nav.familie.felles</groupId>
+            <artifactId>sikkerhet</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-webmvc</artifactId>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-resource-server</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-autoconfigure</artifactId>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-jose</artifactId>
         </dependency>
-        <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
-        </dependency>
-
-
         <!-- Test -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/sikkerhet-spring-security/pom.xml
+++ b/sikkerhet-spring-security/pom.xml
@@ -30,6 +30,10 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-oauth2-jose</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-core</artifactId>
+        </dependency>
         <!-- Test -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/sikkerhet-spring-security/src/main/java/no/nav/familie/sikkerhet/context/FamilieFellesSpringSecurityKonfigurasjon.kt
+++ b/sikkerhet-spring-security/src/main/java/no/nav/familie/sikkerhet/context/FamilieFellesSpringSecurityKonfigurasjon.kt
@@ -1,0 +1,37 @@
+package no.nav.familie.sikkerhet.context
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Konfigurerer [SpringSecurityTokenContext] som [TokenContext]-implementasjon.
+ *
+ * Importer denne i applikasjonens konfigurasjonsklasse for å aktivere Spring Security:
+ *
+ * ```kotlin
+ * @Import(FamilieFellesSpringSecurityKonfigurasjon::class)
+ * @SpringBootApplication
+ * class MyApp
+ * ```
+ *
+ * [SpringSecurityTokenContext.issuerNameMapping] bygges automatisk fra miljøvariablene
+ * `AZURE_OPENID_CONFIG_ISSUER` → `"azuread"`, `TOKEN_X_ISSUER` → `"tokenx"` og `SELVBETJENING_ISSUER` → `"selvbetjening"`.
+ */
+@Configuration(proxyBeanMethods = false)
+class FamilieFellesSpringSecurityKonfigurasjon(
+    @Value("\${AZURE_OPENID_CONFIG_ISSUER:}") private val azureIssuer: String,
+    @Value("\${TOKEN_X_ISSUER:}") private val tokenxIssuer: String,
+    @Value("\${SELVBETJENING_ISSUER:}") private val selvbetjeningIssuer: String,
+) {
+    @Bean
+    fun familieFellesSpringSecurityTokenContext(): SpringSecurityTokenContext {
+        val mapping =
+            buildMap {
+                if (azureIssuer.isNotEmpty()) put(azureIssuer, "azuread")
+                if (tokenxIssuer.isNotEmpty()) put(tokenxIssuer, "tokenx")
+                if (selvbetjeningIssuer.isNotEmpty()) put(selvbetjeningIssuer, "selvbetjening")
+            }
+        return SpringSecurityTokenContext(issuerNameMapping = mapping)
+    }
+}

--- a/sikkerhet-spring-security/src/main/java/no/nav/familie/sikkerhet/context/FamilieFellesSpringSecurityKonfigurasjon.kt
+++ b/sikkerhet-spring-security/src/main/java/no/nav/familie/sikkerhet/context/FamilieFellesSpringSecurityKonfigurasjon.kt
@@ -22,7 +22,7 @@ import org.springframework.context.annotation.Configuration
 class FamilieFellesSpringSecurityKonfigurasjon(
     @Value("\${AZURE_OPENID_CONFIG_ISSUER:}") private val azureIssuer: String,
     @Value("\${TOKEN_X_ISSUER:}") private val tokenxIssuer: String,
-    @Value("\${SELVBETJENING_ISSUER:}") private val selvbetjeningIssuer: String,
+    @Value("\${IDPORTEN_ISSUER:}") private val selvbetjeningIssuer: String,
 ) {
     @Bean
     fun familieFellesSpringSecurityTokenContext(): SpringSecurityTokenContext {

--- a/sikkerhet-spring-security/src/main/java/no/nav/familie/sikkerhet/context/SecurityContextCoroutineContext.kt
+++ b/sikkerhet-spring-security/src/main/java/no/nav/familie/sikkerhet/context/SecurityContextCoroutineContext.kt
@@ -1,0 +1,45 @@
+package no.nav.familie.sikkerhet.context
+
+import kotlinx.coroutines.ThreadContextElement
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextHolder
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Et [CoroutineContext]-element som fanger opp Spring Securitys [SecurityContext] ved coroutine-oppstart
+ * og gjenoppretter den for hver continuation – uavhengig av hvilken tråd coroutinen kjører på.
+ *
+ * Nødvendig fordi [SecurityContextHolder] bruker [ThreadLocal], som ikke følger med coroutiner
+ * på tvers av tråder (f.eks. [kotlinx.coroutines.Dispatchers.IO]).
+ *
+ * Bruk:
+ * ```kotlin
+ * launch(Dispatchers.IO + SecurityContextCoroutineContext()) {
+ *     // SecurityContext er tilgjengelig her
+ * }
+ * ```
+ */
+class SecurityContextCoroutineContext(
+    private val securityContext: SecurityContext = SecurityContextHolder.getContext(),
+) : AbstractCoroutineContextElement(Key),
+    ThreadContextElement<SecurityContext?> {
+    companion object Key : CoroutineContext.Key<SecurityContextCoroutineContext>
+
+    override fun updateThreadContext(context: CoroutineContext): SecurityContext? {
+        val previous = SecurityContextHolder.getContext()
+        SecurityContextHolder.setContext(securityContext)
+        return previous
+    }
+
+    override fun restoreThreadContext(
+        context: CoroutineContext,
+        oldState: SecurityContext?,
+    ) {
+        if (oldState != null) {
+            SecurityContextHolder.setContext(oldState)
+        } else {
+            SecurityContextHolder.clearContext()
+        }
+    }
+}

--- a/sikkerhet-spring-security/src/main/java/no/nav/familie/sikkerhet/context/SpringSecurityTokenContext.kt
+++ b/sikkerhet-spring-security/src/main/java/no/nav/familie/sikkerhet/context/SpringSecurityTokenContext.kt
@@ -1,0 +1,54 @@
+package no.nav.familie.sikkerhet.context
+
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import java.time.Instant
+
+/**
+ * [TokenContext]-implementasjon som bruker Spring Securitys [SecurityContextHolder].
+ *
+ * @param issuerNameMapping Valgfri mapping fra issuer-URL (f.eks. verdien i `iss`-claimet) til
+ *   kortnavnet som brukes i biblioteket (f.eks. `"azuread"`, `"tokenx"`).
+ *   Hvis issuer-URLen finnes i mappingen brukes kortnavnet; ellers brukes issuer-URLen direkte.
+ */
+class SpringSecurityTokenContext(
+    private val issuerNameMapping: Map<String, String> = emptyMap(),
+) : TokenContext {
+    override fun getClaimAsString(
+        claim: String,
+        issuer: String,
+    ): String? = currentJwt(issuer)?.claims?.get(claim)?.toString()
+
+    override fun getClaimAsStringList(
+        claim: String,
+        issuer: String,
+    ): List<String>? {
+        val claimValue = currentJwt(issuer)?.claims?.get(claim) ?: return null
+        return when (claimValue) {
+            is List<*> -> claimValue.filterIsInstance<String>()
+            is String -> listOf(claimValue)
+            else -> null
+        }
+    }
+
+    override fun hasTokenFor(issuer: String): Boolean = currentJwt(issuer) != null
+
+    override fun getBearerToken(issuer: String): String? = currentJwt(issuer)?.tokenValue
+
+    override fun issuers(): Collection<String> {
+        val jwt = currentJwtFromContext() ?: return emptyList()
+        val issUrl = jwt.issuer?.toString() ?: return emptyList()
+        return listOf(issUrl)
+    }
+
+    override fun getExpiry(issuer: String): Instant? = currentJwt(issuer)?.expiresAt
+
+    private fun currentJwt(issuer: String): Jwt? {
+        val jwt = currentJwtFromContext() ?: return null
+        val issUrl = jwt.issuer?.toString() ?: return null
+        return jwt.takeIf { issUrl == issuer || issuerNameMapping[issUrl] == issuer }
+    }
+
+    private fun currentJwtFromContext(): Jwt? = (SecurityContextHolder.getContext().authentication as? JwtAuthenticationToken)?.token
+}

--- a/sikkerhet-spring-security/src/test/java/no/nav/familie/sikkerhet/context/SpringSecurityTokenContextTest.kt
+++ b/sikkerhet-spring-security/src/test/java/no/nav/familie/sikkerhet/context/SpringSecurityTokenContextTest.kt
@@ -1,0 +1,174 @@
+package no.nav.familie.sikkerhet.context
+
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import java.time.Instant
+
+internal class SpringSecurityTokenContextTest {
+    private val azureadIssuerUrl = "https://azuread"
+    private val tokenxIssuerUrl = "https://tokenx"
+    private val selvbetjeningIssuerUrl = "https://selvbetjening"
+
+    private val tokenContext =
+        SpringSecurityTokenContext(
+            issuerNameMapping =
+                mapOf(
+                    azureadIssuerUrl to "azuread",
+                    tokenxIssuerUrl to "tokenx",
+                    selvbetjeningIssuerUrl to "selvbetjening",
+                ),
+        )
+
+    @AfterEach
+    fun tearDown() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `hasTokenFor returnerer true for selvbetjening-token via name mapping`() {
+        mockJwt(selvbetjeningIssuerUrl, mapOf("sub" to "user123"))
+        assertThat(tokenContext.hasTokenFor("azuread")).isFalse()
+        assertThat(tokenContext.hasTokenFor("tokenx")).isFalse()
+        assertThat(tokenContext.hasTokenFor("selvbetjening")).isTrue()
+    }
+
+    @Test
+    fun `hasTokenFor returnerer true for tokenx-token via name mapping`() {
+        mockJwt(tokenxIssuerUrl, mapOf("sub" to "user123"))
+        assertThat(tokenContext.hasTokenFor("azuread")).isFalse()
+        assertThat(tokenContext.hasTokenFor("tokenx")).isTrue()
+        assertThat(tokenContext.hasTokenFor("selvbetjening")).isFalse()
+    }
+
+    @Test
+    fun `hasTokenFor returnerer true for azuread via name mapping`() {
+        mockJwt(azureadIssuerUrl, mapOf("sub" to "user123"))
+        assertThat(tokenContext.hasTokenFor("azuread")).isTrue()
+        assertThat(tokenContext.hasTokenFor("tokenx")).isFalse()
+        assertThat(tokenContext.hasTokenFor("selvbetjening")).isFalse()
+    }
+
+    @Test
+    fun `hasTokenFor returnerer true når jwt matcher issuer-URL direkte`() {
+        mockJwt(azureadIssuerUrl, mapOf("sub" to "user123"))
+        assertThat(tokenContext.hasTokenFor(azureadIssuerUrl)).isTrue()
+    }
+
+    @Test
+    fun `hasTokenFor returnerer false når det ikke finnes et token`() {
+        assertThat(tokenContext.hasTokenFor("azuread")).isFalse()
+    }
+
+    @Test
+    fun `hasTokenFor returnerer false når tokenet ikke er JwtAuthenticationToken`() {
+        val auth = mockk<Authentication>()
+        SecurityContextHolder.getContext().authentication = auth
+        assertThat(tokenContext.hasTokenFor("azuread")).isFalse()
+    }
+
+    @Test
+    fun `getClaimAsString returnerer claim-verdien når den finnes`() {
+        mockJwt(azureadIssuerUrl, mapOf("sub" to "user123", "NAVident" to "Z999999"))
+        assertThat(tokenContext.getClaimAsString("NAVident", "azuread")).isEqualTo("Z999999")
+    }
+
+    @Test
+    fun `getClaimAsString returnerer null når claimet mangler`() {
+        mockJwt(azureadIssuerUrl, mapOf("sub" to "user123"))
+        assertThat(tokenContext.getClaimAsString("missing", "azuread")).isNull()
+    }
+
+    @Test
+    fun `getClaimAsString returnerer null når det ikke finnes token`() {
+        assertThat(tokenContext.getClaimAsString("sub", "azuread")).isNull()
+    }
+
+    @Test
+    fun `getClaimAsString returnerer null når issuer ikke stemmer`() {
+        mockJwt(tokenxIssuerUrl, mapOf("sub" to "user123"))
+        assertThat(tokenContext.getClaimAsString("sub", "azuread")).isNull()
+    }
+
+    @Test
+    fun `getBearerToken returnerer rå token-verdi`() {
+        val tokenValue = "my.jwt.token"
+        mockJwt(azureadIssuerUrl, mapOf("sub" to "user123"), tokenValue = tokenValue)
+        assertThat(tokenContext.getBearerToken("azuread")).isEqualTo(tokenValue)
+    }
+
+    @Test
+    fun `getBearerToken returnerer null når det ikke finnes token`() {
+        assertThat(tokenContext.getBearerToken("azuread")).isNull()
+    }
+
+    @Test
+    fun `issuers returnerer issuer-URL`() {
+        mockJwt(azureadIssuerUrl, mapOf("sub" to "user123"))
+        assertThat(tokenContext.issuers()).containsExactly(azureadIssuerUrl)
+    }
+
+    @Test
+    fun `issuers returnerer tom liste når det ikke finnes token`() {
+        assertThat(tokenContext.issuers()).isEmpty()
+    }
+
+    @Test
+    fun `getClaimAsStringList returnerer liste for List-claim`() {
+        mockJwt(azureadIssuerUrl, mapOf("sub" to "user123", "roles" to listOf("role1", "role2")))
+        assertThat(tokenContext.getClaimAsStringList("roles", "azuread")).containsExactly("role1", "role2")
+    }
+
+    @Test
+    fun `getClaimAsStringList returnerer liste med ett element for String-claim`() {
+        mockJwt(azureadIssuerUrl, mapOf("sub" to "user123", "roles" to "access_as_application"))
+        assertThat(tokenContext.getClaimAsStringList("roles", "azuread")).containsExactly("access_as_application")
+    }
+
+    @Test
+    fun `getClaimAsStringList returnerer null når claimet mangler`() {
+        mockJwt(azureadIssuerUrl, mapOf("sub" to "user123"))
+        assertThat(tokenContext.getClaimAsStringList("roles", "azuread")).isNull()
+    }
+
+    @Test
+    fun `getExpiry returnerer utløpstidspunktet for tokenet`() {
+        val expiresAt = Instant.now().plusSeconds(3600).truncatedTo(java.time.temporal.ChronoUnit.SECONDS)
+        mockJwt(azureadIssuerUrl, mapOf("sub" to "user123"), expiresAt = expiresAt)
+        assertThat(tokenContext.getExpiry("azuread")).isEqualTo(expiresAt)
+    }
+
+    @Test
+    fun `getExpiry returnerer null når issuer ikke stemmer`() {
+        mockJwt(tokenxIssuerUrl, mapOf("sub" to "user123"))
+        assertThat(tokenContext.getExpiry("azuread")).isNull()
+    }
+
+    @Test
+    fun `getExpiry returnerer null når det ikke finnes token`() {
+        assertThat(tokenContext.getExpiry("azuread")).isNull()
+    }
+
+    private fun mockJwt(
+        issuerUrl: String,
+        claims: Map<String, Any>,
+        tokenValue: String = "dummy.jwt.token",
+        expiresAt: Instant = Instant.now().plusSeconds(3600),
+    ) {
+        val jwt =
+            Jwt(
+                tokenValue,
+                Instant.now(),
+                expiresAt,
+                mapOf("alg" to "RS256"),
+                claims + ("iss" to issuerUrl),
+            )
+        val auth = JwtAuthenticationToken(jwt)
+        SecurityContextHolder.getContext().authentication = auth
+    }
+}

--- a/sikkerhet-token-support/README.md
+++ b/sikkerhet-token-support/README.md
@@ -1,0 +1,48 @@
+# sikkerhet-token-support
+
+`TokenContext`-implementasjon basert på **Nav token-support** (`token-validation-spring`).
+
+## Kom i gang
+
+Legg til avhengigheten i `pom.xml`:
+
+```xml
+<dependency>
+    <groupId>no.nav.familie.felles</groupId>
+    <artifactId>sikkerhet-token-support</artifactId>
+    <version>${familie-felles.version}</version>
+</dependency>
+```
+
+Importer deretter konfigurasjonsklassen i applikasjonens hovedklasse eller en `@Configuration`-klasse:
+
+```kotlin
+@Import(FamilieFellesNavTokenSupportKonfigurasjon::class)
+@SpringBootApplication
+class MinApp
+```
+
+Dette registrerer `NavTokenSupportTokenContext` som aktiv `TokenContext`-implementasjon og gjør `TokenContextHolder` tilgjengelig i hele applikasjonen.
+
+## Forutsetninger
+
+Nav token-support må være konfigurert i `application.properties` / `application.yaml` med de issuerne applikasjonen skal validere tokens for. Se [nais/token-support](https://github.com/navikt/token-support#required-properties-yaml-or-properties) for detaljer.
+
+Kortnavnene du oppgir der (f.eks. `azuread`, `tokenx`) er de samme som brukes i metodekallene på `TokenContextHolder`.
+
+## Bruk
+
+Etter at konfigurasjonen er på plass brukes `TokenContextHolder` direkte:
+
+```kotlin
+val saksbehandler = TokenContextHolder.getClaimAsString("NAVident")
+val harAzureToken = TokenContextHolder.hasTokenFor("azuread")
+val bearerToken = TokenContextHolder.getBearerToken("azuread")
+```
+
+## Relaterte moduler
+
+| Modul | Beskrivelse |
+|-------|-------------|
+| `sikkerhet` | Felles API – `TokenContext`-grensesnitt og `TokenContextHolder` |
+| `sikkerhet-spring-security` | Alternativ implementasjon basert på Spring Security OAuth2 Resource Server |

--- a/sikkerhet-token-support/pom.xml
+++ b/sikkerhet-token-support/pom.xml
@@ -10,31 +10,23 @@
         <version>${revision}${sha1}${changelist}</version>
     </parent>
 
-    <artifactId>sikkerhet</artifactId>
+    <artifactId>sikkerhet-token-support</artifactId>
     <version>${revision}${sha1}${changelist}</version>
-    <name>Felles - Sikkerhet</name>
-    <description>Small lib for JWT operations</description>
+    <name>Felles - Sikkerhet Nav Token-Support</name>
+    <description>TokenContext-implementasjon basert på Nav token-support</description>
     <packaging>jar</packaging>
 
     <dependencies>
         <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib</artifactId>
+            <groupId>no.nav.familie.felles</groupId>
+            <artifactId>sikkerhet</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-webmvc</artifactId>
+            <groupId>no.nav.security</groupId>
+            <artifactId>token-validation-spring</artifactId>
+            <version>${nav.security.token.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-autoconfigure</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
-        </dependency>
-
-
         <!-- Test -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -47,6 +39,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test-autoconfigure</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
@@ -54,6 +51,12 @@
         <dependency>
             <groupId>io.mockk</groupId>
             <artifactId>mockk-jvm</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.familie.felles</groupId>
+            <artifactId>sikkerhet-spring-security</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/sikkerhet-token-support/pom.xml
+++ b/sikkerhet-token-support/pom.xml
@@ -27,6 +27,10 @@
             <artifactId>token-validation-spring</artifactId>
             <version>${nav.security.token.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-core</artifactId>
+        </dependency>
         <!-- Test -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/sikkerhet-token-support/src/main/java/no/nav/familie/sikkerhet/context/FamilieFellesNavTokenSupportKonfigurasjon.kt
+++ b/sikkerhet-token-support/src/main/java/no/nav/familie/sikkerhet/context/FamilieFellesNavTokenSupportKonfigurasjon.kt
@@ -1,0 +1,21 @@
+package no.nav.familie.sikkerhet.context
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Konfigurerer [NavTokenSupportTokenContext] som [TokenContext]-implementasjon.
+ *
+ * Importer denne i applikasjonens konfigurasjonsklasse for å aktivere Nav token-support:
+ *
+ * ```kotlin
+ * @Import(FamilieFellesNavTokenSupportKonfigurasjon::class)
+ * @SpringBootApplication
+ * class MyApp
+ * ```
+ */
+@Configuration(proxyBeanMethods = false)
+class FamilieFellesNavTokenSupportKonfigurasjon {
+    @Bean
+    fun familieFellesNavTokenSupportTokenContext(): NavTokenSupportTokenContext = NavTokenSupportTokenContext()
+}

--- a/sikkerhet-token-support/src/main/java/no/nav/familie/sikkerhet/context/NavTokenSupportTokenContext.kt
+++ b/sikkerhet-token-support/src/main/java/no/nav/familie/sikkerhet/context/NavTokenSupportTokenContext.kt
@@ -1,12 +1,14 @@
 package no.nav.familie.sikkerhet.context
 
 import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
+import org.slf4j.LoggerFactory
 import java.time.Instant
 
 /**
  * [TokenContext]-implementasjon som bruker Nav token-support sin [SpringTokenValidationContextHolder].
  */
 class NavTokenSupportTokenContext : TokenContext {
+    private val logger = LoggerFactory.getLogger(NavTokenSupportTokenContext::class.java)
     private val holder = SpringTokenValidationContextHolder()
 
     override fun getClaimAsString(
@@ -34,5 +36,8 @@ class NavTokenSupportTokenContext : TokenContext {
 
     override fun getExpiry(issuer: String): Instant? = getValidationContext()?.getClaims(issuer)?.expirationTime?.toInstant()
 
-    private fun getValidationContext() = runCatching { holder.getTokenValidationContext() }.getOrNull()
+    private fun getValidationContext() =
+        runCatching { holder.getTokenValidationContext() }
+            .onFailure { logger.error("Feil ved henting av token validation context", it) }
+            .getOrNull()
 }

--- a/sikkerhet-token-support/src/main/java/no/nav/familie/sikkerhet/context/NavTokenSupportTokenContext.kt
+++ b/sikkerhet-token-support/src/main/java/no/nav/familie/sikkerhet/context/NavTokenSupportTokenContext.kt
@@ -1,0 +1,38 @@
+package no.nav.familie.sikkerhet.context
+
+import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
+import java.time.Instant
+
+/**
+ * [TokenContext]-implementasjon som bruker Nav token-support sin [SpringTokenValidationContextHolder].
+ */
+class NavTokenSupportTokenContext : TokenContext {
+    private val holder = SpringTokenValidationContextHolder()
+
+    override fun getClaimAsString(
+        claim: String,
+        issuer: String,
+    ): String? = getValidationContext()?.getClaims(issuer)?.get(claim)?.toString()
+
+    override fun getClaimAsStringList(
+        claim: String,
+        issuer: String,
+    ): List<String>? {
+        val claimValue = getValidationContext()?.getClaims(issuer)?.get(claim) ?: return null
+        return when (claimValue) {
+            is List<*> -> claimValue.filterIsInstance<String>()
+            is String -> listOf(claimValue)
+            else -> null
+        }
+    }
+
+    override fun hasTokenFor(issuer: String): Boolean = getValidationContext()?.hasTokenFor(issuer) ?: false
+
+    override fun getBearerToken(issuer: String): String? = getValidationContext()?.getJwtToken(issuer)?.encodedToken
+
+    override fun issuers(): Collection<String> = getValidationContext()?.issuers.orEmpty()
+
+    override fun getExpiry(issuer: String): Instant? = getValidationContext()?.getClaims(issuer)?.expirationTime?.toInstant()
+
+    private fun getValidationContext() = runCatching { holder.getTokenValidationContext() }.getOrNull()
+}

--- a/sikkerhet-token-support/src/main/java/no/nav/familie/sikkerhet/context/RequestContextCoroutineContext.kt
+++ b/sikkerhet-token-support/src/main/java/no/nav/familie/sikkerhet/context/RequestContextCoroutineContext.kt
@@ -1,0 +1,49 @@
+package no.nav.familie.sikkerhet.context
+
+import kotlinx.coroutines.ThreadContextElement
+import org.springframework.web.context.request.RequestAttributes
+import org.springframework.web.context.request.RequestContextHolder
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Et [CoroutineContext]-element som fanger opp Spring Webs [RequestAttributes] ved coroutine-oppstart
+ * og gjenoppretter dem for hver continuation – uavhengig av hvilken tråd coroutinen kjører på.
+ *
+ * Nødvendig fordi nav-token-support lagrer token-valideringskonteksten i [RequestContextHolder]
+ * (ThreadLocal), som ikke følger med coroutiner på tvers av tråder (f.eks. [kotlinx.coroutines.Dispatchers.IO]).
+ *
+ * Bruk:
+ * ```kotlin
+ * launch(Dispatchers.IO + RequestContextCoroutineContext()) {
+ *     // Token-kontekst er tilgjengelig her
+ * }
+ * ```
+ */
+class RequestContextCoroutineContext(
+    private val requestAttributes: RequestAttributes? = RequestContextHolder.getRequestAttributes(),
+) : AbstractCoroutineContextElement(Key),
+    ThreadContextElement<RequestAttributes?> {
+    companion object Key : CoroutineContext.Key<RequestContextCoroutineContext>
+
+    override fun updateThreadContext(context: CoroutineContext): RequestAttributes? {
+        val previous = RequestContextHolder.getRequestAttributes()
+        if (requestAttributes != null) {
+            RequestContextHolder.setRequestAttributes(requestAttributes, false)
+        } else {
+            RequestContextHolder.resetRequestAttributes()
+        }
+        return previous
+    }
+
+    override fun restoreThreadContext(
+        context: CoroutineContext,
+        oldState: RequestAttributes?,
+    ) {
+        if (oldState != null) {
+            RequestContextHolder.setRequestAttributes(oldState, false)
+        } else {
+            RequestContextHolder.resetRequestAttributes()
+        }
+    }
+}

--- a/sikkerhet-token-support/src/test/java/no/nav/familie/sikkerhet/context/NavTokenSupportTokenContextTest.kt
+++ b/sikkerhet-token-support/src/test/java/no/nav/familie/sikkerhet/context/NavTokenSupportTokenContextTest.kt
@@ -1,0 +1,173 @@
+package no.nav.familie.sikkerhet.context
+
+import com.nimbusds.jwt.JWTClaimsSet
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.security.token.support.core.context.TokenValidationContext
+import no.nav.security.token.support.core.jwt.JwtToken
+import no.nav.security.token.support.core.jwt.JwtTokenClaims
+import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.springframework.web.context.request.RequestAttributes
+import org.springframework.web.context.request.RequestContextHolder
+import java.time.Instant
+
+internal class NavTokenSupportTokenContextTest {
+    private val tokenContext = NavTokenSupportTokenContext()
+
+    private val azureadToken =
+        "azuread" to JwtToken("eyJhbGciOiJub25lIn0.eyJzdWIiOiIxMTExMTExMTExMSIsInByZWZlcnJlZF91c2VybmFtZSI6InVzZXJAbmF2Lm5vIn0.")
+    private val tokenxToken = "tokenx" to JwtToken("eyJhbGciOiJub25lIn0.eyJzdWIiOiIyMjIyMjIyMjIyMiIsInBpZCI6IjIyMjIyMjIyMjIyIn0.")
+
+    @AfterEach
+    fun tearDown() {
+        RequestContextHolder.resetRequestAttributes()
+    }
+
+    @Test
+    fun `hasTokenFor returnerer true når token finnes for issueren`() {
+        mockContext(mapOf(azureadToken))
+        assertThat(tokenContext.hasTokenFor("azuread")).isTrue()
+        assertThat(tokenContext.hasTokenFor("tokenx")).isFalse()
+    }
+
+    @Test
+    fun `hasTokenFor returnerer false når det ikke finnes en request context`() {
+        assertThat(tokenContext.hasTokenFor("azuread")).isFalse()
+    }
+
+    @Test
+    fun `issuers returnerer alle issuere med token`() {
+        mockContext(mapOf(azureadToken, tokenxToken))
+        assertThat(tokenContext.issuers()).containsExactlyInAnyOrder("azuread", "tokenx")
+    }
+
+    @Test
+    fun `issuers returnerer tom liste når det ikke finnes en request context`() {
+        assertThat(tokenContext.issuers()).isEmpty()
+    }
+
+    @Test
+    fun `getClaimAsString returnerer claim-verdien når den finnes`() {
+        val claims =
+            JWTClaimsSet
+                .Builder()
+                .subject("user123")
+                .claim("NAVident", "Z999999")
+                .build()
+        val context = mockk<TokenValidationContext>()
+        every { context.getClaims("azuread") } returns JwtTokenClaims(claims)
+        every { context.issuers } returns listOf("azuread")
+        mockContextHolder(context)
+        assertThat(tokenContext.getClaimAsString("NAVident", "azuread")).isEqualTo("Z999999")
+    }
+
+    @Test
+    fun `getClaimAsString returnerer null når claimet mangler`() {
+        val claims = JWTClaimsSet.Builder().subject("user123").build()
+        val context = mockk<TokenValidationContext>()
+        every { context.getClaims("azuread") } returns JwtTokenClaims(claims)
+        every { context.issuers } returns listOf("azuread")
+        mockContextHolder(context)
+        assertThat(tokenContext.getClaimAsString("missing", "azuread")).isNull()
+    }
+
+    @Test
+    fun `getClaimAsString returnerer null når det ikke finnes en request context`() {
+        assertThat(tokenContext.getClaimAsString("sub", "azuread")).isNull()
+    }
+
+    @Test
+    fun `getBearerToken returnerer null når det ikke finnes en request context`() {
+        assertThat(tokenContext.getBearerToken("azuread")).isNull()
+    }
+
+    @Test
+    fun `getClaimAsStringList returnerer liste for List-claim`() {
+        val claims =
+            JWTClaimsSet
+                .Builder()
+                .subject("user123")
+                .claim("roles", listOf("role1", "role2"))
+                .build()
+        val context = mockk<TokenValidationContext>()
+        every { context.getClaims("azuread") } returns JwtTokenClaims(claims)
+        every { context.issuers } returns listOf("azuread")
+        mockContextHolder(context)
+        assertThat(tokenContext.getClaimAsStringList("roles", "azuread")).containsExactly("role1", "role2")
+    }
+
+    @Test
+    fun `getClaimAsStringList returnerer liste med ett element for String-claim`() {
+        val claims =
+            JWTClaimsSet
+                .Builder()
+                .subject("user123")
+                .claim("roles", "access_as_application")
+                .build()
+        val context = mockk<TokenValidationContext>()
+        every { context.getClaims("azuread") } returns JwtTokenClaims(claims)
+        every { context.issuers } returns listOf("azuread")
+        mockContextHolder(context)
+        assertThat(tokenContext.getClaimAsStringList("roles", "azuread")).containsExactly("access_as_application")
+    }
+
+    @Test
+    fun `getClaimAsStringList returnerer null når claimet mangler`() {
+        val claims = JWTClaimsSet.Builder().subject("user123").build()
+        val context = mockk<TokenValidationContext>()
+        every { context.getClaims("azuread") } returns JwtTokenClaims(claims)
+        every { context.issuers } returns listOf("azuread")
+        mockContextHolder(context)
+        assertThat(tokenContext.getClaimAsStringList("roles", "azuread")).isNull()
+    }
+
+    @Test
+    fun `getExpiry returnerer utløpstidspunktet for tokenet`() {
+        val expiry = java.util.Date.from(Instant.now().plusSeconds(3600).truncatedTo(java.time.temporal.ChronoUnit.SECONDS))
+        val claims =
+            JWTClaimsSet
+                .Builder()
+                .subject("user123")
+                .expirationTime(expiry)
+                .build()
+        val context = mockk<TokenValidationContext>()
+        every { context.getClaims("azuread") } returns JwtTokenClaims(claims)
+        every { context.issuers } returns listOf("azuread")
+        mockContextHolder(context)
+        assertThat(tokenContext.getExpiry("azuread")).isEqualTo(expiry.toInstant())
+    }
+
+    @Test
+    fun `getExpiry returnerer null når claimet ikke finnes`() {
+        val claims = JWTClaimsSet.Builder().subject("user123").build()
+        val context = mockk<TokenValidationContext>()
+        every { context.getClaims("azuread") } returns JwtTokenClaims(claims)
+        every { context.issuers } returns listOf("azuread")
+        mockContextHolder(context)
+        assertThat(tokenContext.getExpiry("azuread")).isNull()
+    }
+
+    @Test
+    fun `getExpiry returnerer null når det ikke finnes en request context`() {
+        assertThat(tokenContext.getExpiry("azuread")).isNull()
+    }
+
+    private fun mockContext(issuerTokenMap: Map<String, JwtToken>) {
+        val context = TokenValidationContext(issuerTokenMap)
+        mockContextHolder(context)
+    }
+
+    private fun mockContextHolder(context: TokenValidationContext) {
+        val requestAttributes = mockk<RequestAttributes>()
+        every {
+            requestAttributes.getAttribute(
+                SpringTokenValidationContextHolder::class.java.name,
+                RequestAttributes.SCOPE_REQUEST,
+            )
+        } returns context
+        RequestContextHolder.setRequestAttributes(requestAttributes)
+    }
+}

--- a/sikkerhet-token-support/src/test/java/no/nav/familie/sikkerhet/context/TokenContextHolderKonfigurasjonsTest.kt
+++ b/sikkerhet-token-support/src/test/java/no/nav/familie/sikkerhet/context/TokenContextHolderKonfigurasjonsTest.kt
@@ -14,10 +14,10 @@ import java.time.Instant
 /**
  * Tester oppførselen til [TokenContextHolder] avhengig av hvilke konfigurasjoner som importeres:
  *
- * - **Ingen**: [TokenContextValidationAutoConfiguration] feiler konteksten ved oppstart med [TokenContextConfigurationException].
+ * - **Ingen**: [TokenContextValidationAutoConfiguration] feiler konteksten ved oppstart med [TokenContextKonfigurasjonException].
  * - **Bare [FamilieFellesSpringSecurityKonfigurasjon]**: én bean — konteksten starter uten feil.
  * - **Bare [FamilieFellesNavTokenSupportKonfigurasjon]**: én bean — konteksten starter uten feil.
- * - **Begge**: [TokenContextValidationAutoConfiguration] feiler konteksten ved oppstart med [TokenContextConfigurationException].
+ * - **Begge**: [TokenContextValidationAutoConfiguration] feiler konteksten ved oppstart med [TokenContextKonfigurasjonException].
  * - **Med NAIS-miljøvariabler**: issuerNameMapping bygges automatisk fra `AZURE_OPENID_CONFIG_ISSUER` og `TOKEN_X_ISSUER`.
  */
 internal class TokenContextHolderKonfigurasjonsTest {
@@ -41,7 +41,7 @@ internal class TokenContextHolderKonfigurasjonsTest {
     open class BeggeKonfigurasjoner
 
     @Test
-    fun `ingen konfigurasjon - konteksten feiler ved oppstart med TokenContextConfigurationException`() {
+    fun `ingen konfigurasjon - konteksten feiler ved oppstart med TokenContextKonfigurasjonException`() {
         applicationContextRunner
             .withUserConfiguration(IngenKonfigurasjon::class.java)
             .run { ctx ->
@@ -49,7 +49,7 @@ internal class TokenContextHolderKonfigurasjonsTest {
                 Assertions
                     .assertThat(ctx.startupFailure)
                     .rootCause()
-                    .isInstanceOf(TokenContextConfigurationException::class.java)
+                    .isInstanceOf(TokenContextKonfigurasjonException::class.java)
                     .hasMessageContaining("Ingen TokenContext er konfigurert")
             }
     }
@@ -85,7 +85,7 @@ internal class TokenContextHolderKonfigurasjonsTest {
                 Assertions
                     .assertThat(ctx.startupFailure)
                     .rootCause()
-                    .isInstanceOf(TokenContextConfigurationException::class.java)
+                    .isInstanceOf(TokenContextKonfigurasjonException::class.java)
                     .hasMessageContaining("Flere TokenContext'er er konfigurert")
             }
     }

--- a/sikkerhet-token-support/src/test/java/no/nav/familie/sikkerhet/context/TokenContextHolderKonfigurasjonsTest.kt
+++ b/sikkerhet-token-support/src/test/java/no/nav/familie/sikkerhet/context/TokenContextHolderKonfigurasjonsTest.kt
@@ -1,0 +1,129 @@
+package no.nav.familie.sikkerhet.context
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import java.time.Instant
+
+/**
+ * Tester oppførselen til [TokenContextHolder] avhengig av hvilke konfigurasjoner som importeres:
+ *
+ * - **Ingen**: [TokenContextValidationAutoConfiguration] feiler konteksten ved oppstart med [TokenContextConfigurationException].
+ * - **Bare [FamilieFellesSpringSecurityKonfigurasjon]**: én bean — konteksten starter uten feil.
+ * - **Bare [FamilieFellesNavTokenSupportKonfigurasjon]**: én bean — konteksten starter uten feil.
+ * - **Begge**: [TokenContextValidationAutoConfiguration] feiler konteksten ved oppstart med [TokenContextConfigurationException].
+ * - **Med NAIS-miljøvariabler**: issuerNameMapping bygges automatisk fra `AZURE_OPENID_CONFIG_ISSUER` og `TOKEN_X_ISSUER`.
+ */
+internal class TokenContextHolderKonfigurasjonsTest {
+    private val applicationContextRunner =
+        ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(TokenContextValidationAutoConfiguration::class.java))
+
+    @Configuration
+    open class IngenKonfigurasjon
+
+    @Configuration
+    @Import(FamilieFellesSpringSecurityKonfigurasjon::class)
+    open class BareSpringSecurityKonfigurasjon
+
+    @Configuration
+    @Import(FamilieFellesNavTokenSupportKonfigurasjon::class)
+    open class BareNavTokenSupportKonfigurasjon
+
+    @Configuration
+    @Import(FamilieFellesSpringSecurityKonfigurasjon::class, FamilieFellesNavTokenSupportKonfigurasjon::class)
+    open class BeggeKonfigurasjoner
+
+    @Test
+    fun `ingen konfigurasjon - konteksten feiler ved oppstart med TokenContextConfigurationException`() {
+        applicationContextRunner
+            .withUserConfiguration(IngenKonfigurasjon::class.java)
+            .run { ctx ->
+                Assertions.assertThat(ctx).hasFailed()
+                Assertions
+                    .assertThat(ctx.startupFailure)
+                    .rootCause()
+                    .isInstanceOf(TokenContextConfigurationException::class.java)
+                    .hasMessageContaining("Ingen TokenContext er konfigurert")
+            }
+    }
+
+    @Test
+    fun `bare SpringSecurity - én bean - konteksten starter uten feil`() {
+        applicationContextRunner
+            .withUserConfiguration(BareSpringSecurityKonfigurasjon::class.java)
+            .run { ctx ->
+                Assertions.assertThat(ctx).hasNotFailed()
+                Assertions.assertThat(ctx).hasSingleBean(SpringSecurityTokenContext::class.java)
+                Assertions.assertThat(ctx).doesNotHaveBean(NavTokenSupportTokenContext::class.java)
+            }
+    }
+
+    @Test
+    fun `bare NavTokenSupport - én bean - konteksten starter uten feil`() {
+        applicationContextRunner
+            .withUserConfiguration(BareNavTokenSupportKonfigurasjon::class.java)
+            .run { ctx ->
+                Assertions.assertThat(ctx).hasNotFailed()
+                Assertions.assertThat(ctx).hasSingleBean(NavTokenSupportTokenContext::class.java)
+                Assertions.assertThat(ctx).doesNotHaveBean(SpringSecurityTokenContext::class.java)
+            }
+    }
+
+    @Test
+    fun `begge konfigurasjoner - kontekstoppstart feiler med for mange TokenContext-beans`() {
+        applicationContextRunner
+            .withUserConfiguration(BeggeKonfigurasjoner::class.java)
+            .run { ctx ->
+                Assertions.assertThat(ctx).hasFailed()
+                Assertions
+                    .assertThat(ctx.startupFailure)
+                    .rootCause()
+                    .isInstanceOf(TokenContextConfigurationException::class.java)
+                    .hasMessageContaining("Flere TokenContext'er er konfigurert")
+            }
+    }
+
+    @Test
+    fun `miljøvariabler gir automatisk issuerNameMapping`() {
+        val azureIssuerUrl = "https://login.microsoftonline.com/tenant/v2.0"
+        val tokenxIssuerUrl = "https://tokenx.nav.no"
+
+        applicationContextRunner
+            .withUserConfiguration(BareSpringSecurityKonfigurasjon::class.java)
+            .withPropertyValues(
+                "AZURE_OPENID_CONFIG_ISSUER=$azureIssuerUrl",
+                "TOKEN_X_ISSUER=$tokenxIssuerUrl",
+            ).run { ctx ->
+                Assertions.assertThat(ctx).hasNotFailed()
+
+                mockJwt(azureIssuerUrl)
+                Assertions.assertThat(TokenContextHolder.hasTokenFor("azuread")).isTrue()
+                Assertions.assertThat(TokenContextHolder.hasTokenFor("tokenx")).isFalse()
+
+                mockJwt(tokenxIssuerUrl)
+                Assertions.assertThat(TokenContextHolder.hasTokenFor("tokenx")).isTrue()
+                Assertions.assertThat(TokenContextHolder.hasTokenFor("azuread")).isFalse()
+
+                SecurityContextHolder.clearContext()
+            }
+    }
+}
+
+private fun mockJwt(issuerUrl: String) {
+    val jwt =
+        Jwt(
+            "dummy.jwt.token",
+            Instant.now(),
+            Instant.now().plusSeconds(3600),
+            mapOf("alg" to "RS256"),
+            mapOf("iss" to issuerUrl),
+        )
+    SecurityContextHolder.getContext().authentication = JwtAuthenticationToken(jwt)
+}

--- a/sikkerhet/README.md
+++ b/sikkerhet/README.md
@@ -26,7 +26,7 @@ Legg til avhengigheten i `pom.xml`:
 
 ## Krav: TokenContext-implementasjon
 
-Appen må importere nøyaktig én `TokenContext`-implementasjon. Spring feiler ved oppstart med `TokenContextConfigurationException` hvis ingen eller flere importeres.
+Appen må importere nøyaktig én `TokenContext`-implementasjon. Spring feiler ved oppstart med `TokenContextKonfigurasjonException` hvis ingen eller flere importeres.
 
 Legg til én av følgende avhengigheter og importer tilhørende konfigurasjonsklasse:
 

--- a/sikkerhet/README.md
+++ b/sikkerhet/README.md
@@ -1,0 +1,104 @@
+# sikkerhet
+
+Felles sikkerhetsbibliotek for Familie-applikasjoner. Inneholder `TokenContext`-APIet og hjelpeklasser for å lese JWT-claims, validere tokens og beskytte endepunkter.
+
+## Innhold
+
+| Klasse | Beskrivelse |
+|--------|-------------|
+| `TokenContextHolder` | Statisk inngangsport for å lese claims og tokens fra innkommende JWT |
+| `EksternBrukerUtils` | Hjelpemetoder for eksterne brukere (tokenx / selvbetjening) |
+| `OIDCUtil` | Hjelpeklasse for Nav-ansatte (azuread) — henter NAVident, groups, claims o.l. |
+| `ClientTokenValidationFilter` | Servlet-filter som validerer client credentials / on-behalf-of |
+| `AuthorizationFilter` | Servlet-filter som tillater kun registrerte klient-IDer (`azp`) |
+
+## Kom i gang
+
+Legg til avhengigheten i `pom.xml`:
+
+```xml
+<dependency>
+    <groupId>no.nav.familie.felles</groupId>
+    <artifactId>sikkerhet</artifactId>
+    <version>${familie-felles.version}</version>
+</dependency>
+```
+
+## Krav: TokenContext-implementasjon
+
+Appen må importere nøyaktig én `TokenContext`-implementasjon. Spring feiler ved oppstart med `TokenContextConfigurationException` hvis ingen eller flere importeres.
+
+Legg til én av følgende avhengigheter og importer tilhørende konfigurasjonsklasse:
+
+**Spring Security OAuth2 Resource Server**:
+
+```xml
+<dependency>
+    <groupId>no.nav.familie.felles</groupId>
+    <artifactId>sikkerhet-spring-security</artifactId>
+    <version>${familie-felles.version}</version>
+</dependency>
+```
+
+```kotlin
+@Import(FamilieFellesSpringSecurityKonfigurasjon::class)
+@SpringBootApplication
+class MinApp
+```
+
+**Nav token-support**:
+
+```xml
+<dependency>
+    <groupId>no.nav.familie.felles</groupId>
+    <artifactId>sikkerhet-token-support</artifactId>
+    <version>${familie-felles.version}</version>
+</dependency>
+```
+
+```kotlin
+@Import(FamilieFellesNavTokenSupportKonfigurasjon::class)
+@SpringBootApplication
+class MinApp
+```
+
+> Importer kun én av disse — Spring feiler ved oppstart hvis begge importeres.
+
+## Bruk
+
+### Lese claims (NAV-ansatte / azuread)
+
+```kotlin
+val navIdent = TokenContextHolder.getClaimAsString("NAVident")
+val groups   = TokenContextHolder.getClaimAsStringList("groups")
+val token    = TokenContextHolder.getBearerToken("azuread")
+```
+
+Eller via Spring-beanen `OIDCUtil`:
+
+```kotlin
+@Autowired lateinit var oidcUtil: OIDCUtil
+
+val navIdent = oidcUtil.navIdent
+val groups   = oidcUtil.groups
+```
+
+### Lese FNR (eksterne brukere / tokenx)
+
+```kotlin
+val fnr = EksternBrukerUtils.hentFnrFraToken()
+val erSammeBruker = EksternBrukerUtils.personIdentErLikInnloggetBruker(fnr)
+```
+
+### Beskytte endepunkter med `ClientTokenValidationFilter`
+
+```kotlin
+@Bean
+fun clientTokenValidationFilter(): FilterRegistrationBean<ClientTokenValidationFilter> =
+    FilterRegistrationBean(
+        ClientTokenValidationFilter(
+            acceptClientCredential = true,
+            acceptOnBehalfOf = false,
+        )
+    ).apply { addUrlPatterns("/api/intern/*") }
+```

--- a/sikkerhet/pom.xml
+++ b/sikkerhet/pom.xml
@@ -61,6 +61,17 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <version>${kotlin.version}</version>

--- a/sikkerhet/src/main/java/no/nav/familie/sikkerhet/ClientTokenValidationFilter.kt
+++ b/sikkerhet/src/main/java/no/nav/familie/sikkerhet/ClientTokenValidationFilter.kt
@@ -3,7 +3,7 @@ package no.nav.familie.sikkerhet
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
+import no.nav.familie.sikkerhet.context.TokenContextHolder
 import org.springframework.web.filter.OncePerRequestFilter
 
 /**
@@ -59,14 +59,11 @@ class ClientTokenValidationFilter(
 
     private fun accepted(): Boolean {
         try {
-            val claims = SpringTokenValidationContextHolder().getTokenValidationContext().getClaims(issuerName)
+            val sub = TokenContextHolder.getClaimAsString("sub", issuerName)
+            val oid = TokenContextHolder.getClaimAsString("oid", issuerName)
+            val clientId = TokenContextHolder.getClaimAsString("azp", issuerName)
 
-            val sub = claims.get("sub") as String?
-            val oid = claims.get("oid") as String?
-            val clientId = claims.get("azp") as String?
-
-            @Suppress("UNCHECKED_CAST")
-            val roles = claims.get("roles") as List<String>? ?: emptyList()
+            val roles = TokenContextHolder.getClaimAsStringList("roles", issuerName).orEmpty()
             val accessAsApplication = roles.contains("access_as_application")
 
             val erClientCredential = sub != null && sub == oid

--- a/sikkerhet/src/main/java/no/nav/familie/sikkerhet/EksternBrukerUtils.kt
+++ b/sikkerhet/src/main/java/no/nav/familie/sikkerhet/EksternBrukerUtils.kt
@@ -1,57 +1,50 @@
 package no.nav.familie.sikkerhet
 
-import no.nav.security.token.support.core.context.TokenValidationContext
-import no.nav.security.token.support.core.exceptions.JwtTokenValidatorException
-import no.nav.security.token.support.core.jwt.JwtTokenClaims
-import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
-import org.springframework.web.context.request.RequestContextHolder
+import no.nav.familie.sikkerhet.context.TokenContextHolder
 
 object EksternBrukerUtils {
     const val ISSUER_SELVBETJENING = "selvbetjening"
     const val ISSUER_TOKENX = "tokenx"
 
-    private val TOKEN_VALIDATION_CONTEXT_ATTRIBUTE = SpringTokenValidationContextHolder::class.java.name
-
     private val FNR_REGEX = """[0-9]{11}""".toRegex()
 
+    /**
+     * Henter fødselsnummer fra `pid`- eller `sub`-claimet i tokenet til innlogget ekstern bruker.
+     *
+     * Kaster [JwtTokenInvalidException] hvis kallet ikke skjer i kontekst av en ekstern bruker.
+     */
     fun hentFnrFraToken(): String {
-        val claims = claims()
-        val fnr = (
-            claims.getStringClaim("pid") ?: claims.subject
-                ?: throw JwtTokenValidatorException("Finner ikke sub/pid på token")
-        )
+        val issuer = resolveIssuer()
+        val fnr =
+            (
+                TokenContextHolder.getClaimAsString("pid", issuer)
+                    ?: TokenContextHolder.getClaimAsString("sub", issuer)
+                    ?: throw JwtTokenInvalidException("Finner ikke sub/pid på token")
+            )
         if (!FNR_REGEX.matches(fnr)) {
-            error("$fnr er ikke gyldig fnr")
+            throw JwtTokenInvalidException("Ugyldig fødselsnummer")
         }
         return fnr
     }
 
+    /** Returnerer true hvis [personIdent] er lik fødselsnummeret i innlogget brukers token. */
     fun personIdentErLikInnloggetBruker(personIdent: String): Boolean = personIdent == hentFnrFraToken()
 
-    fun getBearerTokenForLoggedInUser(): String =
-        getFromContext { validationContext, issuer ->
-            validationContext
-                .getJwtToken(
-                    issuer,
-                )?.encodedToken ?: throw JwtTokenValidatorException("Klarte ikke hente token fra issuer $issuer")
-        }
-
-    private fun claims(): JwtTokenClaims =
-        getFromContext { validationContext, issuer ->
-            validationContext.getClaims(issuer)
-        }
-
-    private fun <T> getFromContext(fn: (TokenValidationContext, String) -> T): T {
-        val validationContext = getTokenValidationContext()
-        return when {
-            validationContext.hasTokenFor(ISSUER_SELVBETJENING) -> fn.invoke(validationContext, ISSUER_SELVBETJENING)
-            validationContext.hasTokenFor(ISSUER_TOKENX) -> fn.invoke(validationContext, ISSUER_TOKENX)
-            else -> error("Finner ikke token for ekstern bruker - issuers=${validationContext.issuers}")
-        }
+    /**
+     * Henter bearer token for innlogget ekstern bruker (tokenx eller selvbetjening).
+     *
+     * Kaster [JwtTokenInvalidException] hvis kallet ikke skjer i kontekst av en ekstern bruker.
+     */
+    fun getBearerTokenForLoggedInUser(): String {
+        val issuer = resolveIssuer()
+        return TokenContextHolder.getBearerToken(issuer)
+            ?: throw JwtTokenInvalidException("Klarte ikke hente token fra issuer $issuer")
     }
 
-    private fun getTokenValidationContext(): TokenValidationContext =
-        RequestContextHolder
-            .currentRequestAttributes()
-            .getAttribute(TOKEN_VALIDATION_CONTEXT_ATTRIBUTE, 0) as TokenValidationContext
+    private fun resolveIssuer(): String =
+        when {
+            TokenContextHolder.hasTokenFor(ISSUER_SELVBETJENING) -> ISSUER_SELVBETJENING
+            TokenContextHolder.hasTokenFor(ISSUER_TOKENX) -> ISSUER_TOKENX
+            else -> throw JwtTokenInvalidException("Finner ikke token for ekstern bruker - issuers=${TokenContextHolder.issuers()}")
+        }
 }

--- a/sikkerhet/src/main/java/no/nav/familie/sikkerhet/EksternBrukerUtils.kt
+++ b/sikkerhet/src/main/java/no/nav/familie/sikkerhet/EksternBrukerUtils.kt
@@ -11,7 +11,7 @@ object EksternBrukerUtils {
     /**
      * Henter fødselsnummer fra `pid`- eller `sub`-claimet i tokenet til innlogget ekstern bruker.
      *
-     * Kaster [JwtTokenInvalidException] hvis kallet ikke skjer i kontekst av en ekstern bruker.
+     * Kaster [UgyldigJwtTokenException] hvis kallet ikke skjer i kontekst av en ekstern bruker.
      */
     fun hentFnrFraToken(): String {
         val issuer = resolveIssuer()
@@ -19,10 +19,10 @@ object EksternBrukerUtils {
             (
                 TokenContextHolder.getClaimAsString("pid", issuer)
                     ?: TokenContextHolder.getClaimAsString("sub", issuer)
-                    ?: throw JwtTokenInvalidException("Finner ikke sub/pid på token")
+                    ?: throw UgyldigJwtTokenException("Finner ikke sub/pid på token")
             )
         if (!FNR_REGEX.matches(fnr)) {
-            throw JwtTokenInvalidException("Ugyldig fødselsnummer")
+            throw UgyldigJwtTokenException("Ugyldig fødselsnummer")
         }
         return fnr
     }
@@ -33,18 +33,18 @@ object EksternBrukerUtils {
     /**
      * Henter bearer token for innlogget ekstern bruker (tokenx eller selvbetjening).
      *
-     * Kaster [JwtTokenInvalidException] hvis kallet ikke skjer i kontekst av en ekstern bruker.
+     * Kaster [UgyldigJwtTokenException] hvis kallet ikke skjer i kontekst av en ekstern bruker.
      */
     fun getBearerTokenForLoggedInUser(): String {
         val issuer = resolveIssuer()
         return TokenContextHolder.getBearerToken(issuer)
-            ?: throw JwtTokenInvalidException("Klarte ikke hente token fra issuer $issuer")
+            ?: throw UgyldigJwtTokenException("Klarte ikke hente token fra issuer $issuer")
     }
 
     private fun resolveIssuer(): String =
         when {
             TokenContextHolder.hasTokenFor(ISSUER_SELVBETJENING) -> ISSUER_SELVBETJENING
             TokenContextHolder.hasTokenFor(ISSUER_TOKENX) -> ISSUER_TOKENX
-            else -> throw JwtTokenInvalidException("Finner ikke token for ekstern bruker - issuers=${TokenContextHolder.issuers()}")
+            else -> throw UgyldigJwtTokenException("Finner ikke token for ekstern bruker - issuers=${TokenContextHolder.issuers()}")
         }
 }

--- a/sikkerhet/src/main/java/no/nav/familie/sikkerhet/JwtTokenInvalidException.kt
+++ b/sikkerhet/src/main/java/no/nav/familie/sikkerhet/JwtTokenInvalidException.kt
@@ -1,0 +1,8 @@
+package no.nav.familie.sikkerhet
+
+/**
+ * Kastes når JWT-token mangler forventede claims eller inneholder ugyldig data.
+ */
+class JwtTokenInvalidException(
+    message: String,
+) : RuntimeException(message)

--- a/sikkerhet/src/main/java/no/nav/familie/sikkerhet/OIDCUtil.kt
+++ b/sikkerhet/src/main/java/no/nav/familie/sikkerhet/OIDCUtil.kt
@@ -9,7 +9,7 @@ import java.util.Date
 /**
  * Spring-bean med hjelpemetoder for å lese claims fra azuread-tokenet til innlogget Nav-ansatt.
  *
- * Kaster [JwtTokenInvalidException] hvis et forventet claim mangler i tokenet.
+ * Kaster [UgyldigJwtTokenException] hvis et forventet claim mangler i tokenet.
  * I `dev`- og `mock-auth`-profil returneres hardkodede testverdier.
  */
 @Component
@@ -22,7 +22,7 @@ class OIDCUtil {
 
     fun autentisertBruker(): String = subject ?: jwtError("Fant ikke subject")
 
-    fun jwtError(message: String): Nothing = throw JwtTokenInvalidException(message)
+    fun jwtError(message: String): Nothing = throw UgyldigJwtTokenException(message)
 
     fun getClaim(claim: String): String =
         if (erDevProfil()) {

--- a/sikkerhet/src/main/java/no/nav/familie/sikkerhet/OIDCUtil.kt
+++ b/sikkerhet/src/main/java/no/nav/familie/sikkerhet/OIDCUtil.kt
@@ -1,57 +1,56 @@
 package no.nav.familie.sikkerhet
 
-import no.nav.security.token.support.core.context.TokenValidationContext
-import no.nav.security.token.support.core.context.TokenValidationContextHolder
-import no.nav.security.token.support.core.exceptions.JwtTokenValidatorException
-import no.nav.security.token.support.core.jwt.JwtTokenClaims
+import no.nav.familie.sikkerhet.context.TokenContextHolder
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.core.env.Environment
 import org.springframework.stereotype.Component
 import java.util.Date
 
+/**
+ * Spring-bean med hjelpemetoder for å lese claims fra azuread-tokenet til innlogget Nav-ansatt.
+ *
+ * Kaster [JwtTokenInvalidException] hvis et forventet claim mangler i tokenet.
+ * I `dev`- og `mock-auth`-profil returneres hardkodede testverdier.
+ */
 @Component
-class OIDCUtil(
-    private val ctxHolder: TokenValidationContextHolder,
-) {
+class OIDCUtil {
     @Autowired
     private lateinit var environment: Environment
 
     val subject: String?
-        get() = claimSet().subject
+        get() = TokenContextHolder.getClaimAsString("sub")
 
     fun autentisertBruker(): String = subject ?: jwtError("Fant ikke subject")
 
-    fun jwtError(message: String): Nothing = throw JwtTokenValidatorException(message)
+    fun jwtError(message: String): Nothing = throw JwtTokenInvalidException(message)
 
     fun getClaim(claim: String): String =
         if (erDevProfil()) {
-            claimSet().get(claim)?.toString() ?: "DEV_$claim"
+            TokenContextHolder.getClaimAsString(claim) ?: "DEV_$claim"
         } else {
-            claimSet().get(claim)?.toString() ?: jwtError("Fant ikke claim '$claim' i tokenet")
+            TokenContextHolder.getClaimAsString(claim) ?: jwtError("Fant ikke claim '$claim' i tokenet")
         }
 
-    fun getClaimAsList(claim: String): List<String>? = if (erDevProfil()) listOf("group1") else claimSet().getAsList(claim)
+    fun getClaimAsList(claim: String): List<String>? =
+        if (erDevProfil()) {
+            listOf("group1")
+        } else {
+            TokenContextHolder.getClaimAsStringList(claim)
+        }
 
     val navIdent: String
         get() =
             if (erDevProfil()) {
                 "TEST_Z123"
             } else {
-                claimSet().get("NAVident")?.toString() ?: jwtError("Fant ikke NAVident")
+                TokenContextHolder.getClaimAsString("NAVident") ?: jwtError("Fant ikke NAVident")
             }
 
     val groups: List<String>?
-        get() =
-            (claimSet().get("groups") as List<*>?)
-                ?.filterNotNull()
-                ?.map { it.toString() }
-
-    fun claimSet(): JwtTokenClaims = context().getClaims("azuread")
-
-    private fun context(): TokenValidationContext = ctxHolder.getTokenValidationContext()
+        get() = TokenContextHolder.getClaimAsStringList("groups")
 
     val expiryDate: Date?
-        get() = claimSet()?.expirationTime
+        get() = TokenContextHolder.getExpiry()?.let { Date.from(it) }
 
     private fun erDevProfil(): Boolean =
         environment.activeProfiles.any {

--- a/sikkerhet/src/main/java/no/nav/familie/sikkerhet/UgyldigJwtTokenException.kt
+++ b/sikkerhet/src/main/java/no/nav/familie/sikkerhet/UgyldigJwtTokenException.kt
@@ -3,6 +3,6 @@ package no.nav.familie.sikkerhet
 /**
  * Kastes når JWT-token mangler forventede claims eller inneholder ugyldig data.
  */
-class JwtTokenInvalidException(
+class UgyldigJwtTokenException(
     message: String,
 ) : RuntimeException(message)

--- a/sikkerhet/src/main/java/no/nav/familie/sikkerhet/context/TokenContext.kt
+++ b/sikkerhet/src/main/java/no/nav/familie/sikkerhet/context/TokenContext.kt
@@ -1,0 +1,45 @@
+package no.nav.familie.sikkerhet.context
+
+import java.time.Instant
+
+/**
+ * Token-konteksten for innkommende HTTP-forespørsler, uavhengig av sikkerhetsrammeverk.
+ *
+ * Velg implementasjon ved å importere én konfigurasjon i appen:
+ * - `@Import(FamilieFellesNavTokenSupportKonfigurasjon::class)` — Nav token-support
+ * - `@Import(FamilieFellesSpringSecurityKonfigurasjon::class)` — Spring Security
+ *
+ * Spring feiler ved oppstart med [TokenContextConfigurationException] hvis ingen eller flere
+ * konfigurasjoner importeres. Se [TokenContextValidationAutoConfiguration].
+ */
+interface TokenContext {
+    /**
+     * Henter claimet som en streng for den angitte issueren.
+     * Returnerer null hvis claimet ikke finnes.
+     */
+    fun getClaimAsString(
+        claim: String,
+        issuer: String = "azuread",
+    ): String?
+
+    /**
+     * Henter claimet som en liste av strenger for den angitte issueren.
+     * Returnerer null hvis claimet ikke finnes.
+     */
+    fun getClaimAsStringList(
+        claim: String,
+        issuer: String = "azuread",
+    ): List<String>?
+
+    /** Returnerer true hvis det finnes et validert token for den angitte issueren. */
+    fun hasTokenFor(issuer: String): Boolean
+
+    /** Henter bearer token for den angitte issueren, eller null hvis det ikke finnes. */
+    fun getBearerToken(issuer: String): String?
+
+    /** Alle issuere det finnes validerte tokens for. */
+    fun issuers(): Collection<String>
+
+    /** Utløpstidspunktet for tokenet til den angitte issueren, eller null hvis det ikke finnes. */
+    fun getExpiry(issuer: String = "azuread"): Instant?
+}

--- a/sikkerhet/src/main/java/no/nav/familie/sikkerhet/context/TokenContext.kt
+++ b/sikkerhet/src/main/java/no/nav/familie/sikkerhet/context/TokenContext.kt
@@ -35,7 +35,7 @@ interface TokenContext {
     fun hasTokenFor(issuer: String): Boolean
 
     /** Henter bearer token for den angitte issueren, eller null hvis det ikke finnes. */
-    fun getBearerToken(issuer: String): String?
+    fun getBearerToken(issuer: String = "azuread"): String?
 
     /** Alle issuere det finnes validerte tokens for. */
     fun issuers(): Collection<String>

--- a/sikkerhet/src/main/java/no/nav/familie/sikkerhet/context/TokenContext.kt
+++ b/sikkerhet/src/main/java/no/nav/familie/sikkerhet/context/TokenContext.kt
@@ -9,7 +9,7 @@ import java.time.Instant
  * - `@Import(FamilieFellesNavTokenSupportKonfigurasjon::class)` — Nav token-support
  * - `@Import(FamilieFellesSpringSecurityKonfigurasjon::class)` — Spring Security
  *
- * Spring feiler ved oppstart med [TokenContextConfigurationException] hvis ingen eller flere
+ * Spring feiler ved oppstart med [TokenContextKonfigurasjonException] hvis ingen eller flere
  * konfigurasjoner importeres. Se [TokenContextValidationAutoConfiguration].
  */
 interface TokenContext {

--- a/sikkerhet/src/main/java/no/nav/familie/sikkerhet/context/TokenContextConfigurationException.kt
+++ b/sikkerhet/src/main/java/no/nav/familie/sikkerhet/context/TokenContextConfigurationException.kt
@@ -1,0 +1,9 @@
+package no.nav.familie.sikkerhet.context
+
+/**
+ * Kastes av [TokenContextValidationAutoConfiguration] ved oppstart
+ * hvis ingen eller mer enn én [TokenContext]-bean er registrert.
+ */
+class TokenContextConfigurationException(
+    message: String,
+) : IllegalStateException(message)

--- a/sikkerhet/src/main/java/no/nav/familie/sikkerhet/context/TokenContextHolder.kt
+++ b/sikkerhet/src/main/java/no/nav/familie/sikkerhet/context/TokenContextHolder.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.sikkerhet.context
 
 import no.nav.familie.sikkerhet.context.TokenContextHolder.clearContext
+import no.nav.familie.sikkerhet.context.TokenContextHolder.getContext
 import no.nav.familie.sikkerhet.context.TokenContextHolder.setContext
 import java.time.Instant
 
@@ -27,7 +28,7 @@ object TokenContextHolder {
     }
 
     /**
-     * Nullstiller konteksten slik at [getContext] igjen kaster [TokenContextConfigurationException].
+     * Nullstiller konteksten slik at [getContext] igjen kaster [TokenContextKonfigurasjonException].
      *
      * Brukes i tester for å simulere fravær av konfigurasjon og for opprydding etter tester som setter kontekst.
      * Tilgjengelig for tester via `TokenContextTestHelper` i test-jar.
@@ -39,11 +40,11 @@ object TokenContextHolder {
     /**
      * Returnerer den registrerte [TokenContext]-implementasjonen.
      *
-     * @throws TokenContextConfigurationException hvis ingen kontekst er satt.
+     * @throws TokenContextKonfigurasjonException hvis ingen kontekst er satt.
      */
     internal fun getContext(): TokenContext =
         context
-            ?: throw TokenContextConfigurationException(
+            ?: throw TokenContextKonfigurasjonException(
                 "Ingen TokenContext er konfigurert. " +
                     "Importer én av følgende konfigurasjoner med @Import:\n" +
                     "  FamilieFellesNavTokenSupportKonfigurasjon  (fra sikkerhet-token-support)\n" +

--- a/sikkerhet/src/main/java/no/nav/familie/sikkerhet/context/TokenContextHolder.kt
+++ b/sikkerhet/src/main/java/no/nav/familie/sikkerhet/context/TokenContextHolder.kt
@@ -1,0 +1,51 @@
+package no.nav.familie.sikkerhet.context
+
+import java.time.Instant
+
+/**
+ * Statisk holder for [TokenContext]-strategien, tilsvarende Spring Securitys `SecurityContextHolder`.
+ *
+ * [TokenContextValidationAutoConfiguration] sørger for at nøyaktig én [TokenContext] er konfigurert
+ * ved oppstart, så context aldri er null i en kjørende applikasjon.
+ *
+ * [setContext] og [clearContext] er `internal` og kun beregnet for tester i dette biblioteket.
+ */
+object TokenContextHolder {
+    @Volatile
+    private var context: TokenContext? = null
+
+    internal fun setContext(tokenContext: TokenContext) {
+        context = tokenContext
+    }
+
+    internal fun clearContext() {
+        context = null
+    }
+
+    internal fun getContext(): TokenContext =
+        context
+            ?: throw TokenContextConfigurationException(
+                "Ingen TokenContext er konfigurert. " +
+                    "Importer én av følgende konfigurasjoner med @Import:\n" +
+                    "  FamilieFellesNavTokenSupportKonfigurasjon  (fra sikkerhet-token-support)\n" +
+                    "  FamilieFellesSpringSecurityKonfigurasjon   (fra sikkerhet-spring-security)",
+            )
+
+    fun getClaimAsString(
+        claim: String,
+        issuer: String = "azuread",
+    ): String? = getContext().getClaimAsString(claim, issuer)
+
+    fun getClaimAsStringList(
+        claim: String,
+        issuer: String = "azuread",
+    ): List<String>? = getContext().getClaimAsStringList(claim, issuer)
+
+    fun hasTokenFor(issuer: String): Boolean = getContext().hasTokenFor(issuer)
+
+    fun getBearerToken(issuer: String): String? = getContext().getBearerToken(issuer)
+
+    fun issuers(): Collection<String> = getContext().issuers()
+
+    fun getExpiry(issuer: String = "azuread"): Instant? = getContext().getExpiry(issuer)
+}

--- a/sikkerhet/src/main/java/no/nav/familie/sikkerhet/context/TokenContextHolder.kt
+++ b/sikkerhet/src/main/java/no/nav/familie/sikkerhet/context/TokenContextHolder.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.sikkerhet.context
 
+import no.nav.familie.sikkerhet.context.TokenContextHolder.clearContext
+import no.nav.familie.sikkerhet.context.TokenContextHolder.setContext
 import java.time.Instant
 
 /**
@@ -8,20 +10,37 @@ import java.time.Instant
  * [TokenContextValidationAutoConfiguration] sørger for at nøyaktig én [TokenContext] er konfigurert
  * ved oppstart, så context aldri er null i en kjørende applikasjon.
  *
- * [setContext] og [clearContext] er `internal` og kun beregnet for tester i dette biblioteket.
+ * [setContext] og [clearContext] er `internal` for å forhindre at konteksten settes eller nullstilles i produksjonskode.
  */
 object TokenContextHolder {
     @Volatile
     private var context: TokenContext? = null
 
+    /**
+     * Registrerer [TokenContext]-implementasjonen som skal brukes.
+     *
+     * Kalles av [TokenContextValidationAutoConfiguration] ved oppstart.
+     * Tilgjengelig for tester via `TokenContextTestHelper` i test-jar.
+     */
     internal fun setContext(tokenContext: TokenContext) {
         context = tokenContext
     }
 
+    /**
+     * Nullstiller konteksten slik at [getContext] igjen kaster [TokenContextConfigurationException].
+     *
+     * Brukes i tester for å simulere fravær av konfigurasjon og for opprydding etter tester som setter kontekst.
+     * Tilgjengelig for tester via `TokenContextTestHelper` i test-jar.
+     */
     internal fun clearContext() {
         context = null
     }
 
+    /**
+     * Returnerer den registrerte [TokenContext]-implementasjonen.
+     *
+     * @throws TokenContextConfigurationException hvis ingen kontekst er satt.
+     */
     internal fun getContext(): TokenContext =
         context
             ?: throw TokenContextConfigurationException(

--- a/sikkerhet/src/main/java/no/nav/familie/sikkerhet/context/TokenContextKonfigurasjonException.kt
+++ b/sikkerhet/src/main/java/no/nav/familie/sikkerhet/context/TokenContextKonfigurasjonException.kt
@@ -4,6 +4,6 @@ package no.nav.familie.sikkerhet.context
  * Kastes av [TokenContextValidationAutoConfiguration] ved oppstart
  * hvis ingen eller mer enn én [TokenContext]-bean er registrert.
  */
-class TokenContextConfigurationException(
+class TokenContextKonfigurasjonException(
     message: String,
 ) : IllegalStateException(message)

--- a/sikkerhet/src/main/java/no/nav/familie/sikkerhet/context/TokenContextValidationAutoConfiguration.kt
+++ b/sikkerhet/src/main/java/no/nav/familie/sikkerhet/context/TokenContextValidationAutoConfiguration.kt
@@ -1,0 +1,30 @@
+package no.nav.familie.sikkerhet.context
+
+import org.springframework.boot.autoconfigure.AutoConfiguration
+
+/**
+ * Fail-fast auto-konfigurasjon som validerer at nøyaktig én [TokenContext]-bean er registrert
+ * ved oppstart. Kaster [TokenContextConfigurationException] hvis ingen eller mer enn én bean finnes.
+ *
+ * Aktiveres automatisk av Spring Boot. Importer nøyaktig én av:
+ * - [FamilieFellesNavTokenSupportKonfigurasjon] (fra `sikkerhet-token-support`)
+ * - [FamilieFellesSpringSecurityKonfigurasjon] (fra `sikkerhet-spring-security`)
+ */
+@AutoConfiguration
+class TokenContextValidationAutoConfiguration(
+    tokenContexts: List<TokenContext>,
+) {
+    init {
+        val feilretting =
+            "Importer én av følgende konfigurasjoner med @Import:\n" +
+                "  FamilieFellesNavTokenSupportKonfigurasjon  (fra sikkerhet-token-support)\n" +
+                "  FamilieFellesSpringSecurityKonfigurasjon   (fra sikkerhet-spring-security)"
+        if (tokenContexts.isEmpty()) {
+            throw TokenContextConfigurationException("Ingen TokenContext er konfigurert. $feilretting")
+        }
+        if (tokenContexts.size > 1) {
+            throw TokenContextConfigurationException("Flere TokenContext'er er konfigurert. $feilretting")
+        }
+        TokenContextHolder.setContext(tokenContexts.single())
+    }
+}

--- a/sikkerhet/src/main/java/no/nav/familie/sikkerhet/context/TokenContextValidationAutoConfiguration.kt
+++ b/sikkerhet/src/main/java/no/nav/familie/sikkerhet/context/TokenContextValidationAutoConfiguration.kt
@@ -4,7 +4,7 @@ import org.springframework.boot.autoconfigure.AutoConfiguration
 
 /**
  * Fail-fast auto-konfigurasjon som validerer at nøyaktig én [TokenContext]-bean er registrert
- * ved oppstart. Kaster [TokenContextConfigurationException] hvis ingen eller mer enn én bean finnes.
+ * ved oppstart. Kaster [TokenContextKonfigurasjonException] hvis ingen eller mer enn én bean finnes.
  *
  * Aktiveres automatisk av Spring Boot. Importer nøyaktig én av:
  * - [FamilieFellesNavTokenSupportKonfigurasjon] (fra `sikkerhet-token-support`)
@@ -20,10 +20,10 @@ class TokenContextValidationAutoConfiguration(
                 "  FamilieFellesNavTokenSupportKonfigurasjon  (fra sikkerhet-token-support)\n" +
                 "  FamilieFellesSpringSecurityKonfigurasjon   (fra sikkerhet-spring-security)"
         if (tokenContexts.isEmpty()) {
-            throw TokenContextConfigurationException("Ingen TokenContext er konfigurert. $feilretting")
+            throw TokenContextKonfigurasjonException("Ingen TokenContext er konfigurert. $feilretting")
         }
         if (tokenContexts.size > 1) {
-            throw TokenContextConfigurationException("Flere TokenContext'er er konfigurert. $feilretting")
+            throw TokenContextKonfigurasjonException("Flere TokenContext'er er konfigurert. $feilretting")
         }
         TokenContextHolder.setContext(tokenContexts.single())
     }

--- a/sikkerhet/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sikkerhet/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+no.nav.familie.sikkerhet.context.TokenContextValidationAutoConfiguration

--- a/sikkerhet/src/test/java/no/nav/familie/sikkerhet/EksternBrukerUtilsTest.kt
+++ b/sikkerhet/src/test/java/no/nav/familie/sikkerhet/EksternBrukerUtilsTest.kt
@@ -1,124 +1,134 @@
 package no.nav.familie.sikkerhet
 
-import com.nimbusds.jwt.JWTClaimsSet
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.security.token.support.core.context.TokenValidationContext
-import no.nav.security.token.support.core.jwt.JwtToken
-import no.nav.security.token.support.core.jwt.JwtTokenClaims
+import no.nav.familie.sikkerhet.context.TokenContext
+import no.nav.familie.sikkerhet.context.TokenContextHolder
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.Assertions.catchThrowable
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.springframework.web.context.request.RequestAttributes
-import org.springframework.web.context.request.RequestContextHolder
 
 internal class EksternBrukerUtilsTest {
-    private val selvbetjening = "selvbetjening" to JwtToken("eyJhbGciOiJub25lIn0.eyJzdWIiOiIxMTExMTExMTExMSJ9.")
-    private val tokenx = "tokenx" to JwtToken("eyJhbGciOiJub25lIn0.eyJzdWIiOiIyMjIyMjIyMjIyMiJ9.")
-    private val annetToken = "annetToken" to JwtToken("eyJhbGciOiJub25lIn0.eyJzdWIiOiIyMjIyMjIyMjIyMiJ9.")
-
     private val sub: String = "11111111111"
     private val pid: String = "22222222222"
 
+    private val mockContext = mockk<TokenContext>(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        TokenContextHolder.setContext(mockContext)
+    }
+
     @AfterEach
-    internal fun tearDown() {
-        RequestContextHolder.resetRequestAttributes()
+    fun tearDown() {
+        TokenContextHolder.clearContext()
+    }
+
+    private fun configureContext(
+        hasSelvbetjening: Boolean = false,
+        hasTokenx: Boolean = false,
+        issuers: Collection<String> = emptyList(),
+        selvbetjeningClaims: Map<String, Any?> = emptyMap(),
+        tokenxClaims: Map<String, Any?> = emptyMap(),
+        selvbetjeningBearer: String? = null,
+        tokenxBearer: String? = null,
+    ) {
+        every { mockContext.hasTokenFor("selvbetjening") } returns hasSelvbetjening
+        every { mockContext.hasTokenFor("tokenx") } returns hasTokenx
+        every { mockContext.issuers() } returns issuers
+        every { mockContext.getClaimAsString(any(), "selvbetjening") } answers { selvbetjeningClaims[firstArg()] as? String }
+        every { mockContext.getClaimAsString(any(), "tokenx") } answers { tokenxClaims[firstArg()] as? String }
+        every { mockContext.getBearerToken("selvbetjening") } returns selvbetjeningBearer
+        every { mockContext.getBearerToken("tokenx") } returns tokenxBearer
     }
 
     @Test
     internal fun `skal hente selvbetjening hvis den finnes`() {
-        mockRequestAttributes(mapOf(selvbetjening, tokenx))
+        configureContext(hasSelvbetjening = true, hasTokenx = true, selvbetjeningClaims = mapOf("sub" to sub))
         assertThat(EksternBrukerUtils.hentFnrFraToken()).isEqualTo(sub)
     }
 
     @Test
     internal fun `skal hente tokenx hvis ikke selvbetjening finnes`() {
-        mockRequestAttributes(mapOf(tokenx))
+        configureContext(hasTokenx = true, tokenxClaims = mapOf("sub" to pid))
         assertThat(EksternBrukerUtils.hentFnrFraToken()).isEqualTo(pid)
     }
 
     @Test
     internal fun `skal kaste feil hvis selvbetjening eller tokenx ikke finnes`() {
-        mockRequestAttributes(mapOf(annetToken))
+        configureContext(issuers = listOf("annetToken"))
         assertThat(catchThrowable { EksternBrukerUtils.hentFnrFraToken() })
+            .isInstanceOf(JwtTokenInvalidException::class.java)
             .hasMessage("Finner ikke token for ekstern bruker - issuers=[annetToken]")
     }
 
     @Test
     internal fun `skal kaste feil hvis det ikke finnes en token`() {
-        mockRequestAttributes(emptyMap())
+        configureContext(issuers = emptyList())
         assertThatThrownBy { EksternBrukerUtils.hentFnrFraToken() }
+            .isInstanceOf(JwtTokenInvalidException::class.java)
             .hasMessage("Finner ikke token for ekstern bruker - issuers=[]")
     }
 
     @Test
     internal fun `skal kaste feil hvis det ikke finnes subject eller pid`() {
-        setContextHolder()
+        configureContext(hasSelvbetjening = true)
         assertThatThrownBy { EksternBrukerUtils.hentFnrFraToken() }
+            .isInstanceOf(JwtTokenInvalidException::class.java)
             .hasMessage("Finner ikke sub/pid på token")
     }
 
     @Test
     internal fun `returnerer subject hvis ikke pid finnes`() {
-        setContextHolder(sub = sub)
+        configureContext(hasSelvbetjening = true, selvbetjeningClaims = mapOf("sub" to sub))
         assertThat(EksternBrukerUtils.hentFnrFraToken()).isEqualTo(sub)
     }
 
     @Test
     internal fun `returnerer pid hvis pid og sub finnes finnes`() {
-        setContextHolder(sub = sub, pid = pid)
+        configureContext(hasSelvbetjening = true, selvbetjeningClaims = mapOf("sub" to sub, "pid" to pid))
         assertThat(EksternBrukerUtils.hentFnrFraToken()).isEqualTo(pid)
     }
 
     @Test
     internal fun `returnerer pid hvis kun pid finnes`() {
-        setContextHolder(pid = pid)
+        configureContext(hasSelvbetjening = true, selvbetjeningClaims = mapOf("pid" to pid))
         assertThat(EksternBrukerUtils.hentFnrFraToken()).isEqualTo(pid)
     }
 
     @Test
     internal fun `skal feile hvis sub ikke er 11 siffer langt`() {
-        listOf("1", "123456789012", "abcdefghijk").forEach {
-            assertThatThrownBy {
-                setContextHolder(sub = it)
-                EksternBrukerUtils.hentFnrFraToken()
-            }.hasMessageContaining("er ikke gyldig fnr")
+        listOf("1", "123456789012", "abcdefghijk").forEach { invalid ->
+            configureContext(hasSelvbetjening = true, selvbetjeningClaims = mapOf("sub" to invalid))
+            assertThatThrownBy { EksternBrukerUtils.hentFnrFraToken() }
+                .isInstanceOf(JwtTokenInvalidException::class.java)
+                .hasMessage("Ugyldig fødselsnummer")
         }
     }
 
     @Test
     internal fun `skal feile hvis pid ikke er 11 siffer langt`() {
-        listOf("1", "123456789012", "abcdefghijk").forEach {
-            assertThatThrownBy {
-                setContextHolder(pid = it)
-                EksternBrukerUtils.hentFnrFraToken()
-            }.hasMessageContaining("er ikke gyldig fnr")
+        listOf("1", "123456789012", "abcdefghijk").forEach { invalid ->
+            configureContext(hasSelvbetjening = true, selvbetjeningClaims = mapOf("pid" to invalid))
+            assertThatThrownBy { EksternBrukerUtils.hentFnrFraToken() }
+                .isInstanceOf(JwtTokenInvalidException::class.java)
+                .hasMessage("Ugyldig fødselsnummer")
         }
     }
 
-    private fun setContextHolder(
-        sub: String? = null,
-        pid: String? = null,
-    ) {
-        val builder = JWTClaimsSet.Builder()
-        sub?.let { builder.subject(it) }
-        pid?.let { builder.claim("pid", it) }
-        val tokenValidationContext = mockk<TokenValidationContext>()
-        every { tokenValidationContext.getClaims("selvbetjening") } returns JwtTokenClaims(builder.build())
-        every { tokenValidationContext.hasTokenFor("selvbetjening") } returns true
-        mockAttributes(tokenValidationContext)
+    @Test
+    internal fun `getBearerTokenForLoggedInUser returnerer token for selvbetjening`() {
+        configureContext(hasSelvbetjening = true, selvbetjeningBearer = "my.token")
+        assertThat(EksternBrukerUtils.getBearerTokenForLoggedInUser()).isEqualTo("my.token")
     }
 
-    private fun mockRequestAttributes(issuerShortNameValidatedTokenMap: Map<String, JwtToken>) {
-        val tokenValidationContext = TokenValidationContext(issuerShortNameValidatedTokenMap)
-        mockAttributes(tokenValidationContext)
-    }
-
-    private fun mockAttributes(tokenValidationContext: TokenValidationContext) {
-        val requestAttributes = mockk<RequestAttributes>()
-        every { requestAttributes.getAttribute(any(), any()) } returns tokenValidationContext
-        RequestContextHolder.setRequestAttributes(requestAttributes)
+    @Test
+    internal fun `personIdentErLikInnloggetBruker returnerer true når ident matcher`() {
+        configureContext(hasSelvbetjening = true, selvbetjeningClaims = mapOf("sub" to sub))
+        assertThat(EksternBrukerUtils.personIdentErLikInnloggetBruker(sub)).isTrue()
+        assertThat(EksternBrukerUtils.personIdentErLikInnloggetBruker("99999999999")).isFalse()
     }
 }

--- a/sikkerhet/src/test/java/no/nav/familie/sikkerhet/EksternBrukerUtilsTest.kt
+++ b/sikkerhet/src/test/java/no/nav/familie/sikkerhet/EksternBrukerUtilsTest.kt
@@ -61,7 +61,7 @@ internal class EksternBrukerUtilsTest {
     internal fun `skal kaste feil hvis selvbetjening eller tokenx ikke finnes`() {
         configureContext(issuers = listOf("annetToken"))
         assertThat(catchThrowable { EksternBrukerUtils.hentFnrFraToken() })
-            .isInstanceOf(JwtTokenInvalidException::class.java)
+            .isInstanceOf(UgyldigJwtTokenException::class.java)
             .hasMessage("Finner ikke token for ekstern bruker - issuers=[annetToken]")
     }
 
@@ -69,7 +69,7 @@ internal class EksternBrukerUtilsTest {
     internal fun `skal kaste feil hvis det ikke finnes en token`() {
         configureContext(issuers = emptyList())
         assertThatThrownBy { EksternBrukerUtils.hentFnrFraToken() }
-            .isInstanceOf(JwtTokenInvalidException::class.java)
+            .isInstanceOf(UgyldigJwtTokenException::class.java)
             .hasMessage("Finner ikke token for ekstern bruker - issuers=[]")
     }
 
@@ -77,7 +77,7 @@ internal class EksternBrukerUtilsTest {
     internal fun `skal kaste feil hvis det ikke finnes subject eller pid`() {
         configureContext(hasSelvbetjening = true)
         assertThatThrownBy { EksternBrukerUtils.hentFnrFraToken() }
-            .isInstanceOf(JwtTokenInvalidException::class.java)
+            .isInstanceOf(UgyldigJwtTokenException::class.java)
             .hasMessage("Finner ikke sub/pid på token")
     }
 
@@ -104,7 +104,7 @@ internal class EksternBrukerUtilsTest {
         listOf("1", "123456789012", "abcdefghijk").forEach { invalid ->
             configureContext(hasSelvbetjening = true, selvbetjeningClaims = mapOf("sub" to invalid))
             assertThatThrownBy { EksternBrukerUtils.hentFnrFraToken() }
-                .isInstanceOf(JwtTokenInvalidException::class.java)
+                .isInstanceOf(UgyldigJwtTokenException::class.java)
                 .hasMessage("Ugyldig fødselsnummer")
         }
     }
@@ -114,7 +114,7 @@ internal class EksternBrukerUtilsTest {
         listOf("1", "123456789012", "abcdefghijk").forEach { invalid ->
             configureContext(hasSelvbetjening = true, selvbetjeningClaims = mapOf("pid" to invalid))
             assertThatThrownBy { EksternBrukerUtils.hentFnrFraToken() }
-                .isInstanceOf(JwtTokenInvalidException::class.java)
+                .isInstanceOf(UgyldigJwtTokenException::class.java)
                 .hasMessage("Ugyldig fødselsnummer")
         }
     }

--- a/sikkerhet/src/test/java/no/nav/familie/sikkerhet/context/TokenContextHolderTest.kt
+++ b/sikkerhet/src/test/java/no/nav/familie/sikkerhet/context/TokenContextHolderTest.kt
@@ -59,10 +59,10 @@ internal class TokenContextHolderTest {
     }
 
     @Test
-    fun `getContext kaster TokenContextConfigurationException når ingen kontekst er satt`() {
+    fun `getContext kaster TokenContextKonfigurasjonException når ingen kontekst er satt`() {
         TokenContextHolder.clearContext()
         assertThatThrownBy { TokenContextHolder.getContext() }
-            .isInstanceOf(TokenContextConfigurationException::class.java)
+            .isInstanceOf(TokenContextKonfigurasjonException::class.java)
             .hasMessageContaining("Ingen TokenContext er konfigurert")
     }
 }

--- a/sikkerhet/src/test/java/no/nav/familie/sikkerhet/context/TokenContextHolderTest.kt
+++ b/sikkerhet/src/test/java/no/nav/familie/sikkerhet/context/TokenContextHolderTest.kt
@@ -1,0 +1,68 @@
+package no.nav.familie.sikkerhet.context
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+internal class TokenContextHolderTest {
+    private val mockContext = mockk<TokenContext>(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        TokenContextHolder.setContext(mockContext)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        TokenContextHolder.clearContext()
+    }
+
+    @Test
+    fun `getContext henter konteksten som setContext satt`() {
+        assertThat(TokenContextHolder.getContext()).isSameAs(mockContext)
+    }
+
+    @Test
+    fun `getClaimAsString henter fra kontekst`() {
+        every { mockContext.getClaimAsString("sub", "issuer") } returns "12345"
+        assertThat(TokenContextHolder.getClaimAsString("sub", "issuer")).isEqualTo("12345")
+    }
+
+    @Test
+    fun `hasTokenFor henter fra kontekst`() {
+        every { mockContext.hasTokenFor("issuer") } returns true
+        assertThat(TokenContextHolder.hasTokenFor("issuer")).isTrue()
+    }
+
+    @Test
+    fun `getBearerToken henter fra kontekst`() {
+        every { mockContext.getBearerToken("issuer") } returns "bearer.token"
+        assertThat(TokenContextHolder.getBearerToken("issuer")).isEqualTo("bearer.token")
+    }
+
+    @Test
+    fun `issuers henter fra kontekst`() {
+        every { mockContext.issuers() } returns listOf("azuread", "tokenx")
+        assertThat(TokenContextHolder.issuers()).containsExactly("azuread", "tokenx")
+    }
+
+    @Test
+    fun `getExpiry henter fra kontekst`() {
+        val expiry = Instant.now().plusSeconds(3600)
+        every { mockContext.getExpiry("azuread") } returns expiry
+        assertThat(TokenContextHolder.getExpiry("azuread")).isEqualTo(expiry)
+    }
+
+    @Test
+    fun `getContext kaster TokenContextConfigurationException når ingen kontekst er satt`() {
+        TokenContextHolder.clearContext()
+        assertThatThrownBy { TokenContextHolder.getContext() }
+            .isInstanceOf(TokenContextConfigurationException::class.java)
+            .hasMessageContaining("Ingen TokenContext er konfigurert")
+    }
+}

--- a/sikkerhet/src/test/java/no/nav/familie/sikkerhet/context/TokenContextTestHelper.kt
+++ b/sikkerhet/src/test/java/no/nav/familie/sikkerhet/context/TokenContextTestHelper.kt
@@ -1,0 +1,12 @@
+package no.nav.familie.sikkerhet.context
+
+/**
+ * Testhjelpeklasse som gir tilgang til [TokenContextHolder.setContext] og [TokenContextHolder.clearContext].
+ *
+ * Tilgjengelig via test-jar for andre moduler som trenger å sette opp [TokenContext] i tester.
+ */
+object TokenContextTestHelper {
+    fun setContext(tokenContext: TokenContext) = TokenContextHolder.setContext(tokenContext)
+
+    fun clearContext() = TokenContextHolder.clearContext()
+}

--- a/web-client/src/main/java/no/nav/familie/webflux/filter/BearerTokenFilter.kt
+++ b/web-client/src/main/java/no/nav/familie/webflux/filter/BearerTokenFilter.kt
@@ -1,13 +1,14 @@
 package no.nav.familie.webflux.filter
 
 import com.nimbusds.oauth2.sdk.GrantType
+import no.nav.familie.sikkerhet.context.TokenContextHolder
+import no.nav.familie.sikkerhet.context.TokenContextKonfigurasjonException
 import no.nav.familie.webflux.sts.StsTokenClient
 import no.nav.security.token.support.client.core.ClientProperties
 import no.nav.security.token.support.client.core.OAuth2GrantType
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
 import no.nav.security.token.support.client.spring.ClientConfigurationProperties
 import no.nav.security.token.support.core.exceptions.JwtTokenMissingException
-import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
 import org.springframework.context.annotation.Import
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.ClientRequest
@@ -203,13 +204,11 @@ private fun clientPropertiesForGrantType(
 
 private fun clientCredentialOrJwtBearer() = if (erSystembruker()) OAuth2GrantType.CLIENT_CREDENTIALS else OAuth2GrantType.JWT_BEARER
 
-private fun erSystembruker(): Boolean {
-    return try {
-        val preferredUsername =
-            SpringTokenValidationContextHolder().getTokenValidationContext().getClaims("azuread").get("preferred_username")
-        return preferredUsername == null
-    } catch (e: Exception) {
-        // Ingen request context. Skjer ved kall som har opphav i kjørende applikasjon. Ping etc.
+private fun erSystembruker(): Boolean =
+    try {
+        TokenContextHolder.getClaimAsString("preferred_username") == null
+    } catch (e: TokenContextKonfigurasjonException) {
+        throw e
+    } catch (e: Throwable) {
         true
     }
-}

--- a/web-client/src/test/java/no/nav/familie/webflux/filter/BearerTokenFilterTest.kt
+++ b/web-client/src/test/java/no/nav/familie/webflux/filter/BearerTokenFilterTest.kt
@@ -3,15 +3,12 @@ package no.nav.familie.webflux.filter
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.familie.sikkerhet.context.TokenContext
+import no.nav.familie.sikkerhet.context.TokenContextTestHelper
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
-import no.nav.security.token.support.core.context.TokenValidationContext
-import no.nav.security.token.support.core.jwt.JwtTokenClaims
-import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.springframework.web.context.request.RequestAttributes
-import org.springframework.web.context.request.RequestContextHolder
 import org.springframework.web.reactive.function.client.ClientRequest
 import org.springframework.web.reactive.function.client.ExchangeFunction
 import java.net.URI
@@ -20,9 +17,12 @@ class BearerTokenFilterTest {
     private lateinit var bearerTokenFilter: BearerTokenFilter
 
     private val oAuth2AccessTokenService = mockk<OAuth2AccessTokenService>(relaxed = true)
+    private val tokenContext = mockk<TokenContext>()
 
     @BeforeEach
     fun setup() {
+        TokenContextTestHelper.setContext(tokenContext)
+        every { tokenContext.getClaimAsString(any(), any()) } returns null
         bearerTokenFilter =
             BearerTokenFilter(
                 oAuth2AccessTokenService,
@@ -32,7 +32,7 @@ class BearerTokenFilterTest {
 
     @AfterEach
     internal fun tearDown() {
-        clearBrukerContext()
+        TokenContextTestHelper.clearContext()
     }
 
     @Test
@@ -48,7 +48,7 @@ class BearerTokenFilterTest {
 
     @Test
     fun `intercept bruker grant type jwt token når det finnes saksbehandler context`() {
-        mockBrukerContext("saksbehandler")
+        every { tokenContext.getClaimAsString("preferred_username", any()) } returns "saksbehandler"
 
         val req = mockk<ClientRequest>(relaxed = true, relaxUnitFun = true)
         every { req.url() } returns (URI("http://firstResource.no"))
@@ -57,25 +57,5 @@ class BearerTokenFilterTest {
         bearerTokenFilter.filter(req, execution)
 
         verify { oAuth2AccessTokenService.getAccessToken(clientConfigurationProperties.registration["2"]!!) }
-    }
-
-    private fun mockBrukerContext(preferredUsername: String) {
-        val tokenValidationContext = mockk<TokenValidationContext>()
-        val jwtTokenClaims = mockk<JwtTokenClaims>()
-        val requestAttributes = mockk<RequestAttributes>()
-        RequestContextHolder.setRequestAttributes(requestAttributes)
-        every {
-            requestAttributes.getAttribute(
-                SpringTokenValidationContextHolder::class.java.name,
-                RequestAttributes.SCOPE_REQUEST,
-            )
-        } returns tokenValidationContext
-        every { tokenValidationContext.getClaims("azuread") } returns jwtTokenClaims
-        every { jwtTokenClaims.get("preferred_username") } returns preferredUsername
-        every { jwtTokenClaims.get("NAVident") } returns preferredUsername
-    }
-
-    private fun clearBrukerContext() {
-        RequestContextHolder.resetRequestAttributes()
     }
 }


### PR DESCRIPTION
## Hva er gjort

Introduserer `TokenContext`-abstraksjonen som gjør at `sikkerhet`-modulen ikke lenger er koblet direkte til Nav token-support.

## Nye moduler
- `sikkerhet-token-support` — `TokenContext`-implementasjon basert på Nav token-support (`SpringTokenValidationContextHolder`)
- `sikkerhet-spring-security` — `TokenContext`-implementasjon basert på Spring Security OAuth2 Resource Server

## Endringer
- `TokenContext`-interface med `getClaimAsString`, `getClaimAsStringList`, `hasTokenFor`, `getBearerToken`, `issuers` og `getExpiry`
- `TokenContextHolder` — statisk holder tilsvarende `SecurityContextHolder`, settes ved Spring-oppstart
- Oppdatert `OIDCUtil`, `EksternBrukerUtils`, `ClientTokenValidationFilter` og `BearerTokenClientInterceptor` til å bruke `TokenContextHolder`

## Testdekning
- `TokenContextHolderTest` og `TokenContextHolderKonfigurasjonsTest`
- `SpringSecurityTokenContextTest`
- `NavTokenSupportTokenContextTest`

## Krav

> [!NOTE] 
> Gjelder kun dersom konsumenten bruker `sikkerhet`-modulen direkte eller en av modulene som avhenger av `sikkerhet`-modulen

For at konsumenten skal fungere med denne versjonen av familie-felles, kreves følgende endringer:

### 1. Legg til ny avhengighet for token-kontekst
Legg til én av følgende i `pom.xml`:

Spring Security OAuth2 Resource Server:

```xml
<dependency>
    <groupId>no.nav.familie.felles</groupId>
    <artifactId>sikkerhet-spring-security</artifactId>
</dependency>
```

Nav token-support:

```xml
<dependency>
    <groupId>no.nav.familie.felles</groupId>
    <artifactId>sikkerhet-token-support</artifactId>
</dependency>
```

### 2. Importer tilhørende konfigurasjonsklasse

I applikasjonens `@Configuration`- eller `@SpringBootApplication`-klasse:
- Spring Security: `@Import(FamilieFellesSpringSecurityKonfigurasjon::class)`
- Nav token-support: `@Import(FamilieFellesNavTokenSupportKonfigurasjon::class)`