### PR TITLE
Fjern feillogging ved henting av token validation context

### DIFF
--- a/sikkerhet-token-support/src/main/java/no/nav/familie/sikkerhet/context/NavTokenSupportTokenContext.kt
+++ b/sikkerhet-token-support/src/main/java/no/nav/familie/sikkerhet/context/NavTokenSupportTokenContext.kt
@@ -36,8 +36,5 @@ class NavTokenSupportTokenContext : TokenContext {
 
     override fun getExpiry(issuer: String): Instant? = getValidationContext()?.getClaims(issuer)?.expirationTime?.toInstant()
 
-    private fun getValidationContext() =
-        runCatching { holder.getTokenValidationContext() }
-            .onFailure { logger.error("Feil ved henting av token validation context", it) }
-            .getOrNull()
+    private fun getValidationContext() = runCatching { holder.getTokenValidationContext() }.getOrNull()
 }


### PR DESCRIPTION
## Beskrivelse

Forenkler `getValidationContext()` i `NavTokenSupportTokenContext` ved å fjerne eksplisitt feillogging. Metoden returnerer nå stille `null` dersom `getTokenValidationContext()` kaster en exception, i stedet for å logge en feil.

Loggingen ble vurdert som støy siden dette kan skje i normale situasjoner (f.eks. utenfor en request-kontekst), og ikke nødvendigvis indikerer en feil som bør logges som error.