### PR TITLE
tidslinje: legg til sammenligningsfunksjon-parameter i slåSammenLikePerioder

### DIFF
--- a/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/PeriodeUtvidelser.kt
+++ b/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/PeriodeUtvidelser.kt
@@ -25,13 +25,15 @@ fun <A, B, C, RESULTAT> TidslinjePeriode<A>.biFunksjon(
 ): TidslinjePeriode<RESULTAT> =
     TidslinjePeriode(operator(this.periodeVerdi, operand1.periodeVerdi, operand2.periodeVerdi), lengde, erUendelig)
 
-fun <T> List<TidslinjePeriode<T>>.slåSammenLike(): List<TidslinjePeriode<T>> =
+fun <T> List<TidslinjePeriode<T>>.slåSammenLike(
+    sammenligningsfunksjon: (T?, T?) -> Boolean = { verdi1, verdi2 -> verdi1 == verdi2 },
+): List<TidslinjePeriode<T>> =
     this.fold(emptyList()) { acc, tidslinjePeriode ->
         val sisteElementIAcc = acc.lastOrNull()
 
         if (sisteElementIAcc == null) {
             listOf(tidslinjePeriode)
-        } else if (sisteElementIAcc.periodeVerdi == tidslinjePeriode.periodeVerdi) {
+        } else if (sammenligningsfunksjon(sisteElementIAcc.periodeVerdi.verdi, tidslinjePeriode.periodeVerdi.verdi)) {
             acc.dropLast(1) +
                 TidslinjePeriode(
                     periodeVerdi = sisteElementIAcc.periodeVerdi,

--- a/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/TidslinjeUtvidelser.kt
+++ b/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/TidslinjeUtvidelser.kt
@@ -460,10 +460,12 @@ fun <T> Tidslinje<T>.tilPerioder(): List<Periode<T?>> = this.tilTidslinjePeriode
 
 fun <T> Tidslinje<T>.tilPerioderIkkeNull(): List<Periode<T & Any>> = this.tilPerioder().filtrerIkkeNull()
 
-fun <T> Tidslinje<T>.slåSammenLikePerioder(): Tidslinje<T> =
+fun <T> Tidslinje<T>.slåSammenLikePerioder(
+    sammenligningsfunksjon: (T?, T?) -> Boolean = { verdi1, verdi2 -> verdi1 == verdi2 },
+): Tidslinje<T> =
     Tidslinje(
         startsTidspunkt = this.startsTidspunkt,
-        perioder = this.innhold.slåSammenLike(),
+        perioder = this.innhold.slåSammenLike(sammenligningsfunksjon),
         tidsEnhet = this.tidsEnhet,
     )
 

--- a/tidslinje/src/test/kotlin/no/nav/familie/tidslinje/utvidelser/SlåSammenLikeTest.kt
+++ b/tidslinje/src/test/kotlin/no/nav/familie/tidslinje/utvidelser/SlåSammenLikeTest.kt
@@ -66,4 +66,43 @@ class SlåSammenLikeTest {
         Assertions.assertEquals(sisteDagIApril, perioder[1].tom)
         Assertions.assertEquals("b", perioder[1].verdi)
     }
+
+    @Test
+    fun `slåSammenLike - Skal slå sammen perioder som er like ifølge custom sammenligningsfunksjon`() {
+        val tidslinje =
+            listOf(Periode("A", førsteJanuar, sisteDagIMars), Periode("a", førsteApril, sisteDagIApril)).tilTidslinje()
+
+        val tidslinjeSlåttSammen =
+            tidslinje.slåSammenLikePerioder { verdi1, verdi2 ->
+                verdi1.equals(verdi2, ignoreCase = true)
+            }
+        val perioder = tidslinjeSlåttSammen.tilPerioder()
+
+        Assertions.assertEquals(1, perioder.size)
+
+        Assertions.assertEquals(førsteJanuar, perioder[0].fom)
+        Assertions.assertEquals(sisteDagIApril, perioder[0].tom)
+    }
+
+    @Test
+    fun `slåSammenLike - Skal ikke slå sammen perioder som er ulike ifølge custom sammenligningsfunksjon`() {
+        val tidslinje =
+            listOf(Periode("A", førsteJanuar, sisteDagIMars), Periode("b", førsteApril, sisteDagIApril)).tilTidslinje()
+
+        val tidslinjeSlåttSammen =
+            tidslinje.slåSammenLikePerioder { verdi1, verdi2 ->
+                verdi1.equals(verdi2, ignoreCase = true)
+            }
+        val perioder = tidslinjeSlåttSammen.tilPerioder()
+
+        Assertions.assertEquals(2, perioder.size)
+
+        Assertions.assertEquals(førsteJanuar, perioder[0].fom)
+        Assertions.assertEquals(sisteDagIMars, perioder[0].tom)
+        Assertions.assertEquals("A", perioder[0].verdi)
+
+        Assertions.assertEquals(førsteApril, perioder[1].fom)
+        Assertions.assertEquals(sisteDagIApril, perioder[1].tom)
+        Assertions.assertEquals("b", perioder[1].verdi)
+    }
 }


### PR DESCRIPTION
## Beskrivelse

Utvider `slåSammenLike` og `slåSammenLikePerioder` med en valgfri `sammenligningsfunksjon`-parameter.

**Tidligere** brukte funksjonene alltid standard `==`/`periodeVerdi`-likhet for å avgjøre om perioder skulle slås sammen.

**Nå** kan kallet sende inn en custom lambda, f.eks. for å sammenligne case-insensitivt eller kun på en delmengde av feltene i en dataklasse. Standardverdien er uendret (`verdi1 == verdi2`), så endringen er bakoverkompatibel.

## Endringer

- `PeriodeUtvidelser.kt`: `slåSammenLike` tar nå en `sammenligningsfunksjon: (T?, T?) -> Boolean`
- `TidslinjeUtvidelser.kt`: `slåSammenLikePerioder` videresender parameteren til `slåSammenLike`
- `SlåSammenLikeTest.kt`: To nye tester som verifiserer custom sammenligningsfunksjon (case-insensitiv slåing og ikke-slåing)

## Testdekning

- ✅ Slår sammen perioder som er like ifølge custom sammenligningsfunksjon
- ✅ Slår ikke sammen perioder som er ulike ifølge custom sammenligningsfunksjon