### PR TITLE
fix: fikser hentOboToken for EntraID-klienten

### DIFF
--- a/token-klient/src/main/kotlin/no/nav/familie/felles/tokenklient/entraid/EntraIDClient.kt
+++ b/token-klient/src/main/kotlin/no/nav/familie/felles/tokenklient/entraid/EntraIDClient.kt
@@ -8,6 +8,7 @@ import org.springframework.web.client.RestClient
 @Component
 class EntraIDClient(
     @param:Value("\${NAIS_TOKEN_ENDPOINT}") private val tokenEndpoint: String,
+    @param:Value("\${NAIS_TOKEN_EXCHANGE_ENDPOINT}") private val tokenExchangeEndpoint: String,
 ) {
     private val restClient: RestClient = RestClient.create()
 
@@ -30,6 +31,6 @@ class EntraIDClient(
                 "target" to scope,
                 "user_token" to brukerToken,
             )
-        return TokenHenter.hentToken(restClient, tokenEndpoint, body)
+        return TokenHenter.hentToken(restClient, tokenExchangeEndpoint, body)
     }
 }

--- a/token-klient/src/test/kotlin/no/nav/familie/felles/tokenklient/entraid/EntraIDClientTest.kt
+++ b/token-klient/src/test/kotlin/no/nav/familie/felles/tokenklient/entraid/EntraIDClientTest.kt
@@ -49,6 +49,7 @@ class EntraIDClientTest {
         val client =
             EntraIDClient(
                 tokenEndpoint = "http://localhost:${wireMockServer.port()}/token",
+                tokenExchangeEndpoint = "http://localhost:${wireMockServer.port()}/token",
             )
         val token = client.hentMaskinTilMaskinToken("api://min-tjeneste/.default")
 
@@ -73,6 +74,7 @@ class EntraIDClientTest {
         val client =
             EntraIDClient(
                 tokenEndpoint = "http://localhost:${wireMockServer.port()}/token",
+                tokenExchangeEndpoint = "http://localhost:${wireMockServer.port()}/token",
             )
         client.hentMaskinTilMaskinToken(scope)
 
@@ -99,6 +101,7 @@ class EntraIDClientTest {
         val client =
             EntraIDClient(
                 tokenEndpoint = "http://localhost:${wireMockServer.port()}/token",
+                tokenExchangeEndpoint = "http://localhost:${wireMockServer.port()}/token",
             )
         val token = client.hentOboToken("api://min-tjeneste/.default", "bruker-token")
 
@@ -124,6 +127,7 @@ class EntraIDClientTest {
         val client =
             EntraIDClient(
                 tokenEndpoint = "http://localhost:${wireMockServer.port()}/token",
+                tokenExchangeEndpoint = "http://localhost:${wireMockServer.port()}/token",
             )
         client.hentOboToken(scope, brukerToken)
 


### PR DESCRIPTION
Fikser hentOboToken for entraID. Hadde lest dokumentasjonen feil. Må gå mot eget endepunkt for ALLE exchange tokens.
