### PR TITLE
Flytt generiske tidslinje-hjelpefunksjoner fra familie-ba-sak

### DIFF
--- a/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/Tidslinje.kt
+++ b/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/Tidslinje.kt
@@ -1,9 +1,11 @@
 package no.nav.familie.tidslinje
 
 import no.nav.familie.tidslinje.utvidelser.klipp
+import no.nav.familie.tidslinje.utvidelser.kombinerUtenNullMed
 import no.nav.familie.tidslinje.utvidelser.map
 import no.nav.familie.tidslinje.utvidelser.mapper
 import no.nav.familie.tidslinje.utvidelser.tilPerioder
+import no.nav.familie.tidslinje.utvidelser.trim
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.temporal.TemporalAdjusters
@@ -172,3 +174,10 @@ fun <T, R> Tidslinje<T>.mapVerdiMedUndefined(mapper: (T?) -> R?): Tidslinje<R> =
     this.map { periodeVerdi ->
         mapper(periodeVerdi.verdi)?.let { Verdi(it) } ?: Null()
     }
+
+fun <V> Tidslinje<V>.erIkkeTom() = !this.erTom()
+
+fun <V, H> Tidslinje<V>.harOverlappMed(tidslinje: Tidslinje<H>) =
+    this.kombinerUtenNullMed(tidslinje) { _, _ -> true }.trim(Null()).erIkkeTom()
+
+fun <V, H> Tidslinje<V>.harIkkeOverlappMed(tidslinje: Tidslinje<H>) = !this.harOverlappMed(tidslinje)

--- a/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/BeskjærTidslinjer.kt
+++ b/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/BeskjærTidslinjer.kt
@@ -1,0 +1,90 @@
+package no.nav.familie.tidslinje.utvidelser
+
+import no.nav.familie.tidslinje.Tidslinje
+import no.nav.familie.tidslinje.tilTidslinje
+import no.nav.familie.tidslinje.tomTidslinje
+import java.time.LocalDate
+import java.time.YearMonth
+
+/**
+ * Extension-metode for å beskjære (forkorte) en tidslinje etter til-og-med fra en annen tidslinje
+ * Etter beskjæringen vil tidslinjen maksimalt strekke seg fra [this]s startTidspunkt og til [tidslinje]s sluttTidspunkt
+ * Perioder som ligger helt utenfor grensene vil forsvinne.
+ * Perioden i hver ende som ligger delvis innenfor, vil forkortes.
+ * Hvis ny og eksisterende grenseverdi begge er uendelige, vil den nye benyttes
+ * Beskjæring mot tom tidslinje vil gi tom tidslinje
+ */
+fun <I> Tidslinje<I>.beskjærTilOgMedEtter(tidslinje: Tidslinje<*>): Tidslinje<I> =
+    when {
+        tidslinje.erTom() -> tomTidslinje()
+        else -> klipp(sluttTidspunkt = tidslinje.kalkulerSluttTidspunkt())
+    }
+
+/**
+ * Extension-metode for å beskjære (forkorte) en tidslinje
+ * Etter beskjæringen vil tidslinjen maksimalt strekke seg fra innsendt [fraOgMed] og til [tilOgMed]
+ * Perioder som ligger helt utenfor grensene vil forsvinne.
+ * Perioden i hver ende som ligger delvis innenfor, vil forkortes.
+ * Uendelige endepunkter vil beskjæres til endelig
+ */
+fun <V> Tidslinje<V>.beskjær(
+    fraOgMed: LocalDate,
+    tilOgMed: LocalDate,
+): Tidslinje<V> =
+    when {
+        erTom() -> tomTidslinje()
+        else -> klipp(startTidspunkt = fraOgMed, sluttTidspunkt = tilOgMed)
+    }
+
+/**
+ * Extension-metode for å beskjære fom dato på en tidslinje
+ * Etter beskjæringen vil tidslinjen maksimalt strekke seg fra innsendt [fraOgMed] og til eksisterende tilOgMed
+ */
+fun <V> Tidslinje<V>.beskjærFraOgMed(fraOgMed: LocalDate): Tidslinje<V> =
+    when {
+        erTom() -> tomTidslinje()
+        else -> klipp(startTidspunkt = fraOgMed)
+    }
+
+/**
+ * Extension-metode for å beskjære tom dato på en tidslinje
+ * Etter beskjæringen vil tidslinjen maksimalt strekke seg fra eksisterende fraOgMed og til innsendt [tilOgMed]
+ */
+fun <V> Tidslinje<V>.beskjærTilOgMed(tilOgMed: LocalDate): Tidslinje<V> =
+    when {
+        erTom() -> tomTidslinje()
+        else -> klipp(sluttTidspunkt = tilOgMed)
+    }
+
+/**
+ * Extension-metode for å beskjære tom dato på et map av tidslinjer
+ * Etter beskjæringen vil tidslinjen maksimalt strekke seg fra eksisterende fraOgMed og til innsendt [tilOgMed]
+ */
+fun <K, V> Map<K, Tidslinje<V>>.beskjærTilOgMed(tilOgMed: LocalDate): Map<K, Tidslinje<V>> =
+    this.mapValues { (_, tidslinje) -> tidslinje.beskjærTilOgMed(tilOgMed) }
+
+/**
+ * Extension-metode for å forlenge den siste perioden i en tidslinje til å bli uendelig,
+ * gitt at perioden allerede strekker seg til og med [tidspunktForUendelighet] eller senere.
+ */
+fun <T : Any> Tidslinje<T>.forlengFremtidTilUendelig(tidspunktForUendelighet: LocalDate): Tidslinje<T> {
+    val senesteTomIPerioder = this.tilPerioderIkkeNull().mapNotNull { it.tom }.maxOrNull()
+
+    return if (senesteTomIPerioder != null && senesteTomIPerioder >= tidspunktForUendelighet) {
+        this
+            .tilPerioderIkkeNull()
+            .filter { it.fom != null && it.fom!! < tidspunktForUendelighet }
+            .ifEmpty { return tomTidslinje() }
+            .replaceLast { periode ->
+                if (periode.tom?.let { YearMonth.from(it) } != YearMonth.from(tidspunktForUendelighet)) {
+                    periode.copy(tom = null)
+                } else {
+                    periode
+                }
+            }.tilTidslinje()
+    } else {
+        this.tilPerioderIkkeNull().tilTidslinje()
+    }
+}
+
+private fun <T> List<T>.replaceLast(replacer: (T) -> T): List<T> = this.take(this.size - 1) + replacer(this.last())

--- a/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/BigDecimalTidslinje.kt
+++ b/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/BigDecimalTidslinje.kt
@@ -1,0 +1,20 @@
+package no.nav.familie.tidslinje.utvidelser
+
+import no.nav.familie.tidslinje.Tidslinje
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+fun <K> Map<K, Tidslinje<BigDecimal>>.minus(bTidslinjer: Map<K, Tidslinje<BigDecimal>>): Map<K, Tidslinje<BigDecimal>> =
+    this.join(bTidslinjer) { a, b ->
+        when {
+            a != null && b != null -> a - b
+            else -> a
+        }
+    }
+
+fun <K> Map<K, Tidslinje<BigDecimal>>.sum(): Tidslinje<BigDecimal> =
+    values.kombinerUtenNullOgIkkeTom {
+        it.reduce { sum, verdi -> sum.plus(verdi) }
+    }
+
+fun Tidslinje<BigDecimal>.rundAvTilHeltall(): Tidslinje<BigDecimal> = this.mapIkkeNull { it.setScale(0, RoundingMode.HALF_UP) }

--- a/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/EndreTid.kt
+++ b/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/EndreTid.kt
@@ -1,0 +1,89 @@
+package no.nav.familie.tidslinje.utvidelser
+
+import no.nav.familie.tidslinje.Null
+import no.nav.familie.tidslinje.PRAKTISK_TIDLIGSTE_DAG
+import no.nav.familie.tidslinje.Tidslinje
+import no.nav.familie.tidslinje.TidslinjePeriodeMedDato
+import no.nav.familie.tidslinje.tilPeriodeVerdi
+import no.nav.familie.tidslinje.tilTidslinje
+
+/**
+ * Extension-metode for å konvertere fra dag-basert tidslinje til måned-basert tidslinje
+ * [mapper]-funksjonen tar inn listen av alle dagverdiene i én måned, og returner verdien måneden skal ha
+ * Dagverdiene kommer i samme rekkefølge som dagene i måneden, og vil ha null-verdi hvis dagen ikke har en verdi
+ */
+fun <V> Tidslinje<V>.tilMåned(mapper: (List<V?>) -> V?): Tidslinje<V> =
+    this.konverterTilMåned { _, månedListe ->
+        val månedVerdier = månedListe.first().map { dag -> dag.periodeVerdi.verdi }
+        mapper(månedVerdier).tilPeriodeVerdi()
+    }
+
+/**
+ * Extention-metode som konverterer en dag-basert tidslinje til en måned-basert tidslinje.
+ * [mapper]-funksjonen tar inn verdiene fra de to dagene før og etter månedsskiftet,
+ * det vil si verdiene fra siste dag i forrige måned og første dag i inneværemde måned.
+ * [mapper]-funksjonen kalles bare dersom begge dagene har en verdi.
+ * Return-verdien er innholdet som blir brukt for inneværende måned.
+ * Hvis retur-verdien er null, vil den resulterende måneden mangle verdi.
+ * Funksjonen vil bruke månedsskiftene fra måneden før tidslinjen starter frem til og med siste måned i tidslinjen.
+ */
+fun <V> Tidslinje<V>.tilMånedFraMånedsskifteIkkeNull(
+    mapper: (innholdSisteDagForrigeMåned: V, innholdFørsteDagDenneMåned: V) -> V?,
+): Tidslinje<V> =
+    if (this.erTom()) {
+        this
+    } else {
+        this
+            .konverterTilMåned(antallMndBakoverITid = 1) { _, (forrigeMåned, inneværendeMåned) ->
+                val verdiForrigeMåned = forrigeMåned.lastOrNull()?.periodeVerdi?.verdi
+                val verdiInneværendeMåned = inneværendeMåned.firstOrNull()?.periodeVerdi?.verdi
+
+                if (verdiForrigeMåned == null || verdiInneværendeMåned == null) {
+                    Null()
+                } else {
+                    mapper(verdiForrigeMåned, verdiInneværendeMåned).tilPeriodeVerdi()
+                }
+            }.trim(Null())
+    }
+
+/**
+ * Extention-metode som konverterer en dag-basert tidslinje til en måned-basert tidslinje.
+ * [mapper]-funksjonen tar inn verdiene fra de to dagene før og etter månedsskiftet,
+ * det vil si verdiene fra siste dag i forrige måned og første dag i inneværende måned.
+ * Return-verdien er innholdet som blir brukt for inneværende måned.
+ * Hvis retur-verdien er null, vil den resulterende måneden mangle verdi.
+ * Funksjonen vil bruke månedsskiftene fra måneden før tidslinjen starter frem til og med måneden etter tidslinjen slutter.
+ */
+fun <V> Tidslinje<V>.tilMånedFraMånedsskifte(
+    mapper: (innholdSisteDagForrigeMåned: V?, innholdFørsteDagDenneMåned: V?) -> V?,
+): Tidslinje<V> =
+    if (this.erTom()) {
+        this
+    } else {
+        this
+            .forlengTidslinjeMedEnMåned()
+            .konverterTilMåned(antallMndBakoverITid = 1) { dato, (forrigeMåned, inneværendeMåned) ->
+                val verdiForrigeMåned = forrigeMåned.lastOrNull()?.periodeVerdi?.verdi
+                val verdiInneværendeMåned = inneværendeMåned.firstOrNull()?.periodeVerdi?.verdi
+
+                if (dato == PRAKTISK_TIDLIGSTE_DAG) {
+                    verdiInneværendeMåned.tilPeriodeVerdi()
+                } else {
+                    mapper(verdiForrigeMåned, verdiInneværendeMåned).tilPeriodeVerdi()
+                }
+            }.trim(Null())
+    }
+
+/**
+ * Extension-metode for å forlenge en tidslinje med en ekstra (tom) måned etter tidslinjens sluttidspunkt.
+ */
+fun <V> Tidslinje<V>.forlengTidslinjeMedEnMåned(): Tidslinje<V> =
+    if (this.innhold.lastOrNull()?.erUendelig == true) {
+        this
+    } else {
+        val fom = this.kalkulerSluttTidspunkt().plusDays(1)
+        val tom = fom.plusMonths(1)
+        val nyePerioder = this.tilTidslinjePerioderMedDato() + TidslinjePeriodeMedDato<V>(null, fom, tom)
+
+        nyePerioder.tilTidslinje()
+    }

--- a/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/FiltrerTidslinjer.kt
+++ b/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/FiltrerTidslinjer.kt
@@ -4,6 +4,7 @@ import no.nav.familie.tidslinje.Null
 import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.Udefinert
 import no.nav.familie.tidslinje.Verdi
+import no.nav.familie.tidslinje.beskjærEtter
 
 fun <T> Tidslinje<T>.filtrer(predicate: (T?) -> Boolean) =
     this.map {
@@ -14,3 +15,26 @@ fun <T> Tidslinje<T>.filtrer(predicate: (T?) -> Boolean) =
     }
 
 fun <T> Tidslinje<T>.filtrerIkkeNull(): Tidslinje<T> = filtrer { it != null }
+
+fun <T> Tidslinje<T>.filtrerIkkeNull(filter: (T) -> Boolean): Tidslinje<T> = filtrer { it != null && filter(it) }
+
+/**
+ * Extension-metode for å filtrere tidslinjen mot en boolsk tidslinje
+ * Resultatet får samme lengde som tidslinjen det opereres på
+ * Det vil finnes perioder som tilsvarer periodene fra kilde-tidslinjen,
+ * men innholdet blir null hvis den boolske tidslinjen er false
+ */
+fun <T> Tidslinje<T>.filtrerMed(boolskTidslinje: Tidslinje<Boolean>): Tidslinje<T> =
+    this
+        .kombinerMed(boolskTidslinje) { verdi, erSann ->
+            when (erSann) {
+                true -> verdi
+                else -> null
+            }
+        }.beskjærEtter(this)
+
+/**
+ * Extension-metode for å filtrere innholdet i en map av tidslinjer
+ */
+fun <K, T> Map<K, Tidslinje<T>>.filtrerHverKunVerdi(filter: (T) -> Boolean): Map<K, Tidslinje<T>> =
+    mapValues { (_, tidslinje) -> tidslinje.filtrer { if (it != null) filter(it) else false } }

--- a/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/JoinTidslinjer.kt
+++ b/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/JoinTidslinjer.kt
@@ -19,6 +19,31 @@ fun <K, V, H, R> Map<K, Tidslinje<V>>.join(
     }
 }
 
+/**
+ * Extension-metode for å kombinere to nøkkel-verdi-map'er der verdiene er tidslinjer
+ * Nøkkelen må være av samme type K
+ * Verdiene i tidslinjene i map'en på venstre side må alle være av typen V
+ * Verdiene i tidslinjene i map'en på høyre side må alle være av typen H
+ * Kombinator-funksjonen kalles med verdiene av fra venstre og høyre tidslinje for samme nøkkel og tidspunkt.
+ * Kombinator-funksjonen blir IKKE kalt hvis venstre, høyre eller begge tidslinjer mangler verdi for et tidspunkt
+ * Resultatet er en ny map der nøklene er av type K, og tidslinjene har innhold av typen (nullable) R.
+ * Bare nøkler som finnes i begge map'ene vil finnes i den resulterende map'en
+ */
+fun <K, V, H, R> Map<K, Tidslinje<V>>.joinIkkeNull(
+    høyreTidslinjer: Map<K, Tidslinje<H>>,
+    kombinator: (V, H) -> R?,
+): Map<K, Tidslinje<R>> {
+    val venstreTidslinjer = this
+    val alleNøkler = venstreTidslinjer.keys.intersect(høyreTidslinjer.keys)
+
+    return alleNøkler.associateWith { nøkkel ->
+        val venstreTidslinje = venstreTidslinjer.getOrDefault(nøkkel, tomTidslinje())
+        val høyreTidslinje = høyreTidslinjer.getOrDefault(nøkkel, tomTidslinje())
+
+        venstreTidslinje.kombinerUtenNullMed(høyreTidslinje, kombinator)
+    }
+}
+
 fun <K, V, H, R> Map<K, Tidslinje<V>>.leftJoin(
     høyreTidslinjer: Map<K, Tidslinje<H>>,
     kombinator: (V?, H?) -> R?,

--- a/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/KombinerTidslinjer.kt
+++ b/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/KombinerTidslinjer.kt
@@ -75,3 +75,113 @@ fun <T, R, S, RESULTAT> Tidslinje<T>.kombinerMed(
         kombineringsfunksjon(periodeVerdi1.verdi, periodeVerdi2.verdi, periodeVerdi3.verdi)
             .tilPeriodeVerdi()
     }
+
+/**
+ * Extension-metode for å kombinere to tidslinjer der begge har verdi
+ * Kombinasjonen baserer seg på å iterere gjennom alle tidspunktene
+ * Hver av tidslinjene kan ha ulik type, hhv V og H
+ * Hvis V eller H mangler verdi, så vil ikke resulterende tidslinje få en verdi for det tidspunktet
+ * Kombintor-funksjonen tar ellers V og H og returnerer (nullable) R
+ * Hvis kombinator-funksjonen returner <null>, antas det at tidslinjen ikke skal ha verdi for tidspunktet
+ * Resultatet er en tidslinje med verdi R
+ */
+fun <V, H, R> Tidslinje<V>.kombinerUtenNullMed(
+    høyreTidslinje: Tidslinje<H>,
+    kombineringsfunksjon: (V, H) -> R?,
+): Tidslinje<R> =
+    this.biFunksjon(høyreTidslinje) { periodeverdiVenstre, periodeverdiHøyre ->
+        when {
+            periodeverdiVenstre is Verdi && periodeverdiHøyre is Verdi -> {
+                kombineringsfunksjon(periodeverdiVenstre.verdi, periodeverdiHøyre.verdi).tilPeriodeVerdi()
+            }
+
+            else -> {
+                Null()
+            }
+        }
+    }
+
+/**
+ * Extension-metode for å kombinere liste av tidslinjer
+ * Kombinasjonen baserer seg på å iterere gjennom alle tidspunktene fra alle tidslinjene
+ * Verdi (V) må være av samme type
+ * Kombintor-funksjonen tar inn Iterable<V> og returner (nullable) R
+ * Null-verdier fjernes før de sendes til kombinator-funksjonen, som betyr at en tom iterator kan bli sendt
+ * Hvis resultatet fra kombinatoren er null, tolkes det som at det ikke skal være en verdi
+ * Resultatet er en tidslinje med verdi R
+ */
+fun <V, R> Collection<Tidslinje<V>>.kombinerUtenNull(listeKombinator: (Iterable<V>) -> R?): Tidslinje<R> =
+    kombiner { it.filterNotNull().let(listeKombinator) }
+
+/**
+ * Extension-metode for å kombinere liste av tidslinjer
+ * Kombinasjonen baserer seg på å iterere gjennom alle tidspunktene fra alle tidslinjene
+ * Verdi (V) må være av samme type
+ * Kombintor-funksjonen tar inn Iterable<V> og returner (nullable) R
+ * Null-verdier fjernes, og listen av verdier sendes til kombinator-funksjonen bare hvis den inneholder verdier
+ * Hvis reesultatet fra kombinatoren er null, tolkes det som at det ikke skal være en verdi
+ * Resultatet er en tidslinje med verdi R
+ */
+fun <V, R> Collection<Tidslinje<V>>.kombinerUtenNullOgIkkeTom(listeKombinator: (Iterable<V>) -> R?): Tidslinje<R> =
+    kombiner { it.filterNotNull().takeIf { it.isNotEmpty() }?.let(listeKombinator) }
+
+/**
+ * Extension-metode for å kombinere liste av tidslinjer
+ * Kombinasjonen baserer seg på å iterere gjennom alle tidspunktene fra alle tidslinjene
+ * Verdien V må være av samme type
+ * Resultatet er en tidslinje med verdi Iterable<V>
+ */
+fun <V> Collection<Tidslinje<V>>.kombiner() = this.kombiner { if (it.toList().isNotEmpty()) it else null }
+
+/**
+ * Extension-metode for å kombinere en nøkkel-verdi-map'er der verdiene er tidslinjer, med en enkelt tidslinje
+ * Verdien i tidslinjene i map'en på venstre side må alle være av typen V
+ * Verdien i tidslinjen på høyre side er av typen H
+ * Kombinator-funksjonen kalles for hvert tidspunkt med med verdien for det tidspunktet fra høyre tidslinje og
+ * verdien fra den enkelte av venstre tidslinjer etter tur.
+ * Kombinator-funksjonen blir IKKE kalt hvis venstre, høyre eller begge tidslinjer mangler verdi for et tidspunkt
+ * Resultatet er en ny map der nøklene er av type K, og tidslinjene har verdi av typen (nullable) R.
+ */
+fun <K, V, H, R> Map<K, Tidslinje<V>>.kombinerKunVerdiMed(
+    høyreTidslinje: Tidslinje<H>,
+    kombinator: (V, H) -> R?,
+): Map<K, Tidslinje<R>> {
+    val venstreTidslinjer = this
+
+    return venstreTidslinjer.mapValues { (_, venstreTidslinje) ->
+        venstreTidslinje.kombinerUtenNullMed(høyreTidslinje, kombinator)
+    }
+}
+
+/**
+ * Extension-metode for å kombinere tre tidslinjer
+ * Kombinasjonen baserer seg på å iterere gjennom alle tidspunktene fra alle tidslinjene
+ * Hver av tidslinjene kan ha ulik type, hhv A, B og C
+ * Kombintor-funksjonen tar inn av A, B og C og returner (nullable) R
+ * Resultatet er en tidslinje med verdi R
+ */
+fun <A, B, C, R> Tidslinje<A>.kombinerKunVerdiMed(
+    tidslinjeB: Tidslinje<B>,
+    tidslinjeC: Tidslinje<C>,
+    kombinator: (A, B, C) -> R?,
+): Tidslinje<R> =
+    this.kombinerMed(tidslinjeB, tidslinjeC) { a, b, c ->
+        when {
+            a != null && b != null && c != null -> kombinator(a, b, c)
+            else -> null
+        }
+    }
+
+/**
+ * Extension-metode for å kombinere to tidslinjer der høyre tidslinje kan være null.
+ * Hvis [høyreTidslinje] er null, returneres [this] uendret.
+ */
+fun <V, H> Tidslinje<V>.kombinerMedNullable(
+    høyreTidslinje: Tidslinje<H>?,
+    kombinator: (V?, H?) -> V?,
+): Tidslinje<V> =
+    if (høyreTidslinje != null) {
+        kombinerMed(høyreTidslinje, kombinator)
+    } else {
+        this
+    }

--- a/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/MapTidslinje.kt
+++ b/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/MapTidslinje.kt
@@ -1,0 +1,21 @@
+package no.nav.familie.tidslinje.utvidelser
+
+import no.nav.familie.tidslinje.Null
+import no.nav.familie.tidslinje.Tidslinje
+import no.nav.familie.tidslinje.Udefinert
+import no.nav.familie.tidslinje.Verdi
+
+/**
+ * Extension-metode for å mappe verdiene i en tidslinje der null-verdier håndteres eksplisitt.
+ * [mapper]-funksjonen kalles bare for perioder som har en (ikke-null) verdi.
+ * Hvis [mapper] returnerer null, blir resultatet en periode uten verdi (Null).
+ * Udefinerte perioder forblir udefinerte.
+ */
+fun <V, R> Tidslinje<V>.mapIkkeNull(mapper: (V) -> R?): Tidslinje<R> =
+    this.map { periodeVerdi ->
+        when (periodeVerdi) {
+            is Verdi -> mapper(periodeVerdi.verdi)?.let { Verdi(it) } ?: Null()
+            is Null -> Null()
+            is Udefinert -> Udefinert()
+        }
+    }

--- a/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/PeriodeUtils.kt
+++ b/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/PeriodeUtils.kt
@@ -1,0 +1,28 @@
+package no.nav.familie.tidslinje.utvidelser
+
+import no.nav.familie.tidslinje.PRAKTISK_TIDLIGSTE_DAG
+import no.nav.familie.tidslinje.Periode
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.temporal.ChronoUnit
+
+fun <V> Periode<V>.splittPerMåned(tilOgMedMåned: YearMonth): List<Periode<V>> {
+    val førsteMåned = YearMonth.from(this.fom ?: PRAKTISK_TIDLIGSTE_DAG)
+    val sisteMåned = setOfNotNull(this.tom?.let { YearMonth.from(it) }, tilOgMedMåned).minOrNull()!!
+
+    return generateSequence(førsteMåned) { it.plusMonths(1) }
+        .takeWhile { !it.isAfter(sisteMåned) }
+        .map {
+            Periode(
+                verdi = this.verdi,
+                fom = it.atDay(1),
+                tom = it.atEndOfMonth(),
+            )
+        }.toList()
+}
+
+fun Periode<*>.erMinst12Måneder(): Boolean = ChronoUnit.MONTHS.between(fom, tom ?: LocalDate.now()) >= 12
+
+fun Periode<*>.erMinst6Måneder(): Boolean = ChronoUnit.MONTHS.between(fom, tom ?: LocalDate.now()) >= 6
+
+fun Periode<*>.erMinst12MånederMedNullTomSomUendelig(): Boolean = tom?.let { ChronoUnit.MONTHS.between(fom, tom) >= 12 } ?: true

--- a/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/SammenliknbarTidslinje.kt
+++ b/tidslinje/src/main/kotlin/no/nav/familie/tidslinje/utvidelser/SammenliknbarTidslinje.kt
@@ -1,0 +1,8 @@
+package no.nav.familie.tidslinje.utvidelser
+
+import no.nav.familie.tidslinje.Tidslinje
+
+fun <K, V : Comparable<V>> minsteAvHver(
+    aTidslinjer: Map<K, Tidslinje<V>>,
+    bTidslinjer: Map<K, Tidslinje<V>>,
+): Map<K, Tidslinje<V>> = aTidslinjer.joinIkkeNull(bTidslinjer) { a, b -> minOf(a, b) }

--- a/tidslinje/src/test/kotlin/no/nav/familie/tidslinje/utvidelser/BeskjærTidslinjerTest.kt
+++ b/tidslinje/src/test/kotlin/no/nav/familie/tidslinje/utvidelser/BeskjærTidslinjerTest.kt
@@ -1,0 +1,102 @@
+package no.nav.familie.tidslinje.utvidelser
+
+import no.nav.familie.tidslinje.Periode
+import no.nav.familie.tidslinje.tilTidslinje
+import no.nav.familie.tidslinje.tomTidslinje
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class BeskjærTidslinjerTest {
+    private val jan = LocalDate.of(2022, 1, 1)
+    private val jun = LocalDate.of(2022, 6, 30)
+    private val des = LocalDate.of(2022, 12, 31)
+
+    @Test
+    fun `beskjærTilOgMedEtter forkorter tidslinjen til sluttidspunktet til den andre tidslinjen`() {
+        val tidslinje = listOf(Periode("a", jan, des)).tilTidslinje()
+        val annen = listOf(Periode("b", jan, jun)).tilTidslinje()
+
+        val resultat = tidslinje.beskjærTilOgMedEtter(annen)
+
+        assertEquals(jun, resultat.kalkulerSluttTidspunkt())
+    }
+
+    @Test
+    fun `beskjærTilOgMedEtter mot tom tidslinje gir tom tidslinje`() {
+        val tidslinje = listOf(Periode("a", jan, des)).tilTidslinje()
+
+        val resultat = tidslinje.beskjærTilOgMedEtter(tomTidslinje<String>())
+
+        assertTrue(resultat.erTom())
+    }
+
+    @Test
+    fun `beskjær forkorter til gitt fom og tom`() {
+        val tidslinje = listOf(Periode("a", jan, des)).tilTidslinje()
+
+        val resultat = tidslinje.beskjær(jan.plusMonths(1), jun)
+
+        assertEquals(jan.plusMonths(1), resultat.startsTidspunkt)
+        assertEquals(jun, resultat.kalkulerSluttTidspunkt())
+    }
+
+    @Test
+    fun `beskjærFraOgMed forkorter bare start`() {
+        val tidslinje = listOf(Periode("a", jan, des)).tilTidslinje()
+
+        val resultat = tidslinje.beskjærFraOgMed(jun)
+
+        assertEquals(jun, resultat.startsTidspunkt)
+        assertEquals(des, resultat.kalkulerSluttTidspunkt())
+    }
+
+    @Test
+    fun `beskjærTilOgMed forkorter bare slutt`() {
+        val tidslinje = listOf(Periode("a", jan, des)).tilTidslinje()
+
+        val resultat = tidslinje.beskjærTilOgMed(jun)
+
+        assertEquals(jan, resultat.startsTidspunkt)
+        assertEquals(jun, resultat.kalkulerSluttTidspunkt())
+    }
+
+    @Test
+    fun `beskjærTilOgMed for map av tidslinjer beskjærer alle verdiene`() {
+        val map =
+            mapOf(
+                "a" to listOf(Periode(1, jan, des)).tilTidslinje(),
+                "b" to listOf(Periode(2, jan, des)).tilTidslinje(),
+            )
+
+        val resultat = map.beskjærTilOgMed(jun)
+
+        assertEquals(jun, resultat.getValue("a").kalkulerSluttTidspunkt())
+        assertEquals(jun, resultat.getValue("b").kalkulerSluttTidspunkt())
+    }
+
+    @Test
+    fun `forlengFremtidTilUendelig forlenger siste periode til uendelig hvis den strekker seg forbi tidspunktet`() {
+        val tidslinje =
+            listOf(
+                Periode("a", jan, jun),
+                Periode("b", jun.plusDays(1), des),
+            ).tilTidslinje()
+
+        val resultat = tidslinje.forlengFremtidTilUendelig(des.minusMonths(1))
+
+        val perioder = resultat.tilPerioderIkkeNull()
+        assertEquals(2, perioder.size)
+        assertEquals(null, perioder.last().tom)
+    }
+
+    @Test
+    fun `forlengFremtidTilUendelig gjør ingenting hvis siste periode ikke strekker seg forbi tidspunktet`() {
+        val tidslinje = listOf(Periode("a", jan, jun)).tilTidslinje()
+
+        val resultat = tidslinje.forlengFremtidTilUendelig(des)
+
+        assertEquals(jun, resultat.tilPerioderIkkeNull().single().tom)
+    }
+}

--- a/tidslinje/src/test/kotlin/no/nav/familie/tidslinje/utvidelser/BigDecimalTidslinjeTest.kt
+++ b/tidslinje/src/test/kotlin/no/nav/familie/tidslinje/utvidelser/BigDecimalTidslinjeTest.kt
@@ -1,0 +1,46 @@
+package no.nav.familie.tidslinje.utvidelser
+
+import no.nav.familie.tidslinje.Periode
+import no.nav.familie.tidslinje.tilTidslinje
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.time.LocalDate
+
+class BigDecimalTidslinjeTest {
+    private val jan = LocalDate.of(2022, 1, 1)
+    private val des = LocalDate.of(2022, 12, 31)
+
+    @Test
+    fun `minus trekker fra hver tidslinje i map'en per nøkkel`() {
+        val a = mapOf("a" to listOf(Periode(BigDecimal.TEN, jan, des)).tilTidslinje())
+        val b = mapOf("a" to listOf(Periode(BigDecimal.ONE, jan, des)).tilTidslinje())
+
+        val resultat = a.minus(b)
+
+        assertEquals(listOf(BigDecimal("9")), resultat.getValue("a").tilPerioder().map { it.verdi })
+    }
+
+    @Test
+    fun `sum summerer verdiene fra alle tidslinjene i map'en`() {
+        val map =
+            mapOf(
+                "a" to listOf(Periode(BigDecimal.ONE, jan, des)).tilTidslinje(),
+                "b" to listOf(Periode(BigDecimal.TEN, jan, des)).tilTidslinje(),
+            )
+
+        val resultat = map.sum()
+
+        assertEquals(listOf(BigDecimal("11")), resultat.tilPerioder().map { it.verdi })
+    }
+
+    @Test
+    fun `rundAvTilHeltall runder av til nærmeste heltall`() {
+        val tidslinje = listOf(Periode(BigDecimal("1.5"), jan, des)).tilTidslinje()
+
+        val resultat = tidslinje.rundAvTilHeltall()
+
+        assertEquals(BigDecimal("1.5").setScale(0, RoundingMode.HALF_UP), resultat.tilPerioder().single().verdi)
+    }
+}

--- a/tidslinje/src/test/kotlin/no/nav/familie/tidslinje/utvidelser/EndreTidTest.kt
+++ b/tidslinje/src/test/kotlin/no/nav/familie/tidslinje/utvidelser/EndreTidTest.kt
@@ -1,0 +1,71 @@
+package no.nav.familie.tidslinje.utvidelser
+
+import no.nav.familie.tidslinje.Periode
+import no.nav.familie.tidslinje.tilTidslinje
+import no.nav.familie.tidslinje.tomTidslinje
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class EndreTidTest {
+    @Test
+    fun `tilMåned konverterer en dag-basert tidslinje til en måned-basert tidslinje`() {
+        val dagTidslinje =
+            listOf(
+                Periode(1, LocalDate.of(2022, 1, 1), LocalDate.of(2022, 1, 31)),
+                Periode(2, LocalDate.of(2022, 2, 1), LocalDate.of(2022, 2, 28)),
+            ).tilTidslinje()
+
+        val månedTidslinje = dagTidslinje.tilMåned { it.filterNotNull().sum() }
+
+        assertEquals(listOf(1, 2), månedTidslinje.tilPerioder().map { it.verdi })
+    }
+
+    @Test
+    fun `tilMånedFraMånedsskifteIkkeNull gir tom tidslinje hvis alle dager er innenfor én måned`() {
+        val dagTidslinje = listOf(Periode("a", LocalDate.of(2021, 12, 7), LocalDate.of(2021, 12, 12))).tilTidslinje()
+
+        val månedTidslinje = dagTidslinje.tilMånedFraMånedsskifteIkkeNull { _, _ -> "b" }
+
+        assertTrue(månedTidslinje.erTom())
+    }
+
+    @Test
+    fun `tilMånedFraMånedsskifteIkkeNull gir en måned ved ett månedsskifte`() {
+        val dagTidslinje = listOf(Periode("x", LocalDate.of(2021, 11, 28), LocalDate.of(2021, 12, 4))).tilTidslinje()
+
+        val månedTidslinje = dagTidslinje.tilMånedFraMånedsskifteIkkeNull { _, verdiFørsteDagDenneMåned -> verdiFørsteDagDenneMåned }
+
+        val perioder = månedTidslinje.tilPerioderIkkeNull()
+        assertEquals(1, perioder.size)
+        assertEquals("x", perioder.single().verdi)
+    }
+
+    @Test
+    fun `tilMånedFraMånedsskifte håndterer at én av dagene mangler verdi`() {
+        val dagTidslinje = tomTidslinje<String>(startsTidspunkt = LocalDate.of(2022, 1, 1))
+
+        val månedTidslinje = dagTidslinje.tilMånedFraMånedsskifte { _, _ -> "uansett" }
+
+        assertTrue(månedTidslinje.erTom())
+    }
+
+    @Test
+    fun `forlengTidslinjeMedEnMåned legger til en ekstra tom måned etter tidslinjens slutt`() {
+        val tidslinje = listOf(Periode("a", LocalDate.of(2022, 1, 1), LocalDate.of(2022, 1, 31))).tilTidslinje()
+
+        val resultat = tidslinje.forlengTidslinjeMedEnMåned()
+
+        assertEquals(LocalDate.of(2022, 3, 1), resultat.kalkulerSluttTidspunkt())
+    }
+
+    @Test
+    fun `forlengTidslinjeMedEnMåned gjør ingenting hvis tidslinjen allerede er uendelig`() {
+        val tidslinje = Periode("a", LocalDate.of(2022, 1, 1), null).tilTidslinje()
+
+        val resultat = tidslinje.forlengTidslinjeMedEnMåned()
+
+        assertEquals(tidslinje, resultat)
+    }
+}

--- a/tidslinje/src/test/kotlin/no/nav/familie/tidslinje/utvidelser/FiltrerTidslinjerUtvidetTest.kt
+++ b/tidslinje/src/test/kotlin/no/nav/familie/tidslinje/utvidelser/FiltrerTidslinjerUtvidetTest.kt
@@ -1,0 +1,49 @@
+package no.nav.familie.tidslinje.utvidelser
+
+import no.nav.familie.tidslinje.Periode
+import no.nav.familie.tidslinje.tilTidslinje
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class FiltrerTidslinjerUtvidetTest {
+    private val jan = LocalDate.of(2022, 1, 1)
+    private val des = LocalDate.of(2022, 12, 31)
+
+    @Test
+    fun `filtrerIkkeNull med predikat filtrerer vekk verdier som ikke oppfyller filteret`() {
+        val tidslinje =
+            listOf(
+                Periode(1, jan, jan.plusMonths(5)),
+                Periode(2, jan.plusMonths(6), des),
+            ).tilTidslinje()
+
+        val resultat = tidslinje.filtrerIkkeNull { it > 1 }
+
+        assertEquals(listOf(2), resultat.tilPerioderIkkeNull().map { it.verdi })
+    }
+
+    @Test
+    fun `filtrerMed setter verdi til null der den boolske tidslinjen er false`() {
+        val verdier = listOf(Periode("a", jan, des)).tilTidslinje()
+        val boolsk = listOf(Periode(true, jan, jan.plusMonths(5)), Periode(false, jan.plusMonths(6), des)).tilTidslinje()
+
+        val resultat = verdier.filtrerMed(boolsk)
+
+        assertEquals(listOf("a"), resultat.tilPerioderIkkeNull().map { it.verdi })
+    }
+
+    @Test
+    fun `filtrerHverKunVerdi filtrerer alle tidslinjer i et map`() {
+        val map =
+            mapOf(
+                "a" to listOf(Periode(1, jan, des)).tilTidslinje(),
+                "b" to listOf(Periode(5, jan, des)).tilTidslinje(),
+            )
+
+        val resultat = map.filtrerHverKunVerdi { it > 2 }
+
+        assertEquals(0, resultat.getValue("a").tilPerioderIkkeNull().size)
+        assertEquals(1, resultat.getValue("b").tilPerioderIkkeNull().size)
+    }
+}

--- a/tidslinje/src/test/kotlin/no/nav/familie/tidslinje/utvidelser/JoinIkkeNullTest.kt
+++ b/tidslinje/src/test/kotlin/no/nav/familie/tidslinje/utvidelser/JoinIkkeNullTest.kt
@@ -1,0 +1,35 @@
+package no.nav.familie.tidslinje.utvidelser
+
+import no.nav.familie.tidslinje.Periode
+import no.nav.familie.tidslinje.tilTidslinje
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class JoinIkkeNullTest {
+    private val jan = LocalDate.of(2022, 1, 1)
+    private val des = LocalDate.of(2022, 12, 31)
+
+    @Test
+    fun `joinIkkeNull kombinerer to map'er per nøkkel og dropper nøkler som bare finnes i den ene`() {
+        val venstre = mapOf("a" to listOf(Periode(1, jan, des)).tilTidslinje(), "b" to listOf(Periode(2, jan, des)).tilTidslinje())
+        val høyre = mapOf("a" to listOf(Periode(10, jan, des)).tilTidslinje(), "c" to listOf(Periode(20, jan, des)).tilTidslinje())
+
+        val resultat = venstre.joinIkkeNull(høyre) { v, h -> v + h }
+
+        assertEquals(setOf("a"), resultat.keys)
+        assertEquals(listOf(Periode(11, jan, des)), resultat.getValue("a").tilPerioder())
+    }
+
+    @Test
+    fun `joinIkkeNull kaller ikke kombinator hvis en av sidene mangler verdi for et tidspunkt`() {
+        val venstre = mapOf("a" to listOf(Periode(1, jan, jan.plusMonths(5))).tilTidslinje())
+        val høyre = mapOf("a" to listOf(Periode(10, jan.plusMonths(3), des)).tilTidslinje())
+
+        val resultat = venstre.joinIkkeNull(høyre) { v, h -> v + h }
+
+        val perioder = resultat.getValue("a").tilPerioderIkkeNull()
+        assertEquals(1, perioder.size)
+        assertEquals(11, perioder.single().verdi)
+    }
+}

--- a/tidslinje/src/test/kotlin/no/nav/familie/tidslinje/utvidelser/KombinerUtenNullTest.kt
+++ b/tidslinje/src/test/kotlin/no/nav/familie/tidslinje/utvidelser/KombinerUtenNullTest.kt
@@ -1,0 +1,112 @@
+package no.nav.familie.tidslinje.utvidelser
+
+import no.nav.familie.tidslinje.Periode
+import no.nav.familie.tidslinje.Tidslinje
+import no.nav.familie.tidslinje.erIkkeTom
+import no.nav.familie.tidslinje.harIkkeOverlappMed
+import no.nav.familie.tidslinje.harOverlappMed
+import no.nav.familie.tidslinje.tilTidslinje
+import no.nav.familie.tidslinje.tomTidslinje
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class KombinerUtenNullTest {
+    private val jan = LocalDate.of(2022, 1, 1)
+    private val des = LocalDate.of(2022, 12, 31)
+
+    @Test
+    fun `kombinerUtenNullMed kaller bare kombinator hvis begge tidslinjer har verdi`() {
+        val venstre = listOf(Periode("a", jan, jan.plusMonths(5))).tilTidslinje()
+        val høyre = listOf(Periode("b", jan.plusMonths(3), des)).tilTidslinje()
+
+        val resultat = venstre.kombinerUtenNullMed(høyre) { v, h -> v + h }
+
+        val perioder = resultat.tilPerioderIkkeNull()
+        assertEquals(1, perioder.size)
+        assertEquals("ab", perioder.single().verdi)
+    }
+
+    @Test
+    fun `kombinerUtenNull filtrerer bort null-verdier før listeKombinator kalles`() {
+        val a = listOf(Periode("a", jan, des)).tilTidslinje()
+        val b = tomTidslinje<String>(startsTidspunkt = jan)
+
+        val resultat = listOf(a, b).kombinerUtenNull { it.joinToString("") }
+
+        assertEquals(listOf("a"), resultat.tilPerioder().map { it.verdi })
+    }
+
+    @Test
+    fun `kombinerUtenNullOgIkkeTom kaller ikke listeKombinator hvis alle er null`() {
+        val a = tomTidslinje<String>(startsTidspunkt = jan)
+        val b = tomTidslinje<String>(startsTidspunkt = jan)
+
+        val resultat = listOf(a, b).kombinerUtenNullOgIkkeTom { it.joinToString("") }
+
+        assertTrue(resultat.erTom())
+    }
+
+    @Test
+    fun `kombinerKunVerdiMed for map av tidslinjer kombinerer hver verdi med en felles tidslinje`() {
+        val venstre = mapOf("a" to listOf(Periode(1, jan, des)).tilTidslinje())
+        val høyre = listOf(Periode(10, jan, des)).tilTidslinje()
+
+        val resultat = venstre.kombinerKunVerdiMed(høyre) { v, h -> v + h }
+
+        assertEquals(listOf(11), resultat.getValue("a").tilPerioder().map { it.verdi })
+    }
+
+    @Test
+    fun `kombinerKunVerdiMed for tre tidslinjer krever verdi i alle tre`() {
+        val a = listOf(Periode(1, jan, des)).tilTidslinje()
+        val b = listOf(Periode(2, jan, des)).tilTidslinje()
+        val c = listOf(Periode(3, jan.plusMonths(6), des)).tilTidslinje()
+
+        val resultat = a.kombinerKunVerdiMed(b, c) { x, y, z -> x + y + z }
+
+        assertEquals(1, resultat.tilPerioderIkkeNull().size)
+        assertEquals(6, resultat.tilPerioderIkkeNull().single().verdi)
+    }
+
+    @Test
+    fun erIkkeTom() {
+        assertFalse(tomTidslinje<Int>().erIkkeTom())
+        assertTrue(listOf(Periode(1, jan, des)).tilTidslinje().erIkkeTom())
+    }
+
+    @Test
+    fun `harOverlappMed og harIkkeOverlappMed`() {
+        val a = listOf(Periode(1, jan, jan.plusMonths(5))).tilTidslinje()
+        val overlappende = listOf(Periode(2, jan.plusMonths(3), des)).tilTidslinje()
+        val ikkeOverlappende = listOf(Periode(2, des.plusDays(1), des.plusMonths(2))).tilTidslinje()
+
+        assertTrue(a.harOverlappMed(overlappende))
+        assertFalse(a.harIkkeOverlappMed(overlappende))
+
+        assertFalse(a.harOverlappMed(ikkeOverlappende))
+        assertTrue(a.harIkkeOverlappMed(ikkeOverlappende))
+    }
+
+    @Test
+    fun `kombinerMedNullable returnerer this uendret hvis den andre tidslinjen er null`() {
+        val a = listOf(Periode(1, jan, des)).tilTidslinje()
+        val nullTidslinje: Tidslinje<Int>? = null
+
+        val resultat = a.kombinerMedNullable(nullTidslinje) { v, _ -> v }
+
+        assertEquals(a, resultat)
+    }
+
+    @Test
+    fun `kombinerMedNullable kombinerer normalt hvis den andre tidslinjen ikke er null`() {
+        val a = listOf(Periode(1, jan, des)).tilTidslinje()
+        val b = listOf(Periode(2, jan, des)).tilTidslinje()
+
+        val resultat = a.kombinerMedNullable(b) { v1, v2 -> (v1 ?: 0) + (v2 ?: 0) }
+
+        assertEquals(listOf(3), resultat.tilPerioder().map { it.verdi })
+    }
+}

--- a/tidslinje/src/test/kotlin/no/nav/familie/tidslinje/utvidelser/MapTidslinjeTest.kt
+++ b/tidslinje/src/test/kotlin/no/nav/familie/tidslinje/utvidelser/MapTidslinjeTest.kt
@@ -1,0 +1,25 @@
+package no.nav.familie.tidslinje.utvidelser
+
+import no.nav.familie.tidslinje.Periode
+import no.nav.familie.tidslinje.tilTidslinje
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class MapTidslinjeTest {
+    private val jan = LocalDate.of(2022, 1, 1)
+    private val des = LocalDate.of(2022, 12, 31)
+
+    @Test
+    fun `mapIkkeNull mapper bare perioder som har verdi`() {
+        val tidslinje =
+            listOf(
+                Periode<Int?>(1, jan, jan.plusMonths(5)),
+                Periode<Int?>(null, jan.plusMonths(5).plusDays(1), des),
+            ).tilTidslinje()
+
+        val resultat = tidslinje.mapIkkeNull { it?.times(10) }
+
+        assertEquals(listOf(10, null), resultat.tilPerioder().map { it.verdi })
+    }
+}

--- a/tidslinje/src/test/kotlin/no/nav/familie/tidslinje/utvidelser/PeriodeUtilsTest.kt
+++ b/tidslinje/src/test/kotlin/no/nav/familie/tidslinje/utvidelser/PeriodeUtilsTest.kt
@@ -1,0 +1,55 @@
+package no.nav.familie.tidslinje.utvidelser
+
+import no.nav.familie.tidslinje.Periode
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.YearMonth
+
+class PeriodeUtilsTest {
+    @Test
+    fun `splittPerMåned deler en periode opp i én periode per måned`() {
+        val periode = Periode("a", LocalDate.of(2022, 1, 15), LocalDate.of(2022, 3, 10))
+
+        val resultat = periode.splittPerMåned(YearMonth.of(2022, 3))
+
+        assertEquals(3, resultat.size)
+        assertEquals(LocalDate.of(2022, 1, 1), resultat[0].fom)
+        assertEquals(LocalDate.of(2022, 1, 31), resultat[0].tom)
+        assertEquals(LocalDate.of(2022, 3, 1), resultat[2].fom)
+        assertEquals(LocalDate.of(2022, 3, 31), resultat[2].tom)
+    }
+
+    @Test
+    fun `splittPerMåned begrenses av tilOgMedMåned selv om perioden strekker seg lenger`() {
+        val periode = Periode("a", LocalDate.of(2022, 1, 1), LocalDate.of(2022, 12, 31))
+
+        val resultat = periode.splittPerMåned(YearMonth.of(2022, 2))
+
+        assertEquals(2, resultat.size)
+    }
+
+    @Test
+    fun `erMinst12Måneder og erMinst6Måneder`() {
+        val periode12 = Periode("a", LocalDate.of(2021, 1, 1), LocalDate.of(2022, 1, 1))
+        val periode6 = Periode("a", LocalDate.of(2021, 1, 1), LocalDate.of(2021, 7, 1))
+        val periode1 = Periode("a", LocalDate.of(2021, 1, 1), LocalDate.of(2021, 2, 1))
+
+        assertTrue(periode12.erMinst12Måneder())
+        assertTrue(periode12.erMinst6Måneder())
+        assertFalse(periode6.erMinst12Måneder())
+        assertTrue(periode6.erMinst6Måneder())
+        assertFalse(periode1.erMinst6Måneder())
+    }
+
+    @Test
+    fun `erMinst12MånederMedNullTomSomUendelig behandler null tom som uendelig`() {
+        val uendelig = Periode("a", LocalDate.of(2021, 1, 1), null)
+        val kort = Periode("a", LocalDate.of(2021, 1, 1), LocalDate.of(2021, 2, 1))
+
+        assertTrue(uendelig.erMinst12MånederMedNullTomSomUendelig())
+        assertFalse(kort.erMinst12MånederMedNullTomSomUendelig())
+    }
+}

--- a/tidslinje/src/test/kotlin/no/nav/familie/tidslinje/utvidelser/SammenliknbarTidslinjeTest.kt
+++ b/tidslinje/src/test/kotlin/no/nav/familie/tidslinje/utvidelser/SammenliknbarTidslinjeTest.kt
@@ -1,0 +1,22 @@
+package no.nav.familie.tidslinje.utvidelser
+
+import no.nav.familie.tidslinje.Periode
+import no.nav.familie.tidslinje.tilTidslinje
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class SammenliknbarTidslinjeTest {
+    private val jan = LocalDate.of(2022, 1, 1)
+    private val des = LocalDate.of(2022, 12, 31)
+
+    @Test
+    fun `minsteAvHver velger den minste verdien per nøkkel og tidspunkt`() {
+        val a = mapOf("a" to listOf(Periode(5, jan, des)).tilTidslinje())
+        val b = mapOf("a" to listOf(Periode(3, jan, des)).tilTidslinje())
+
+        val resultat = minsteAvHver(a, b)
+
+        assertEquals(listOf(3), resultat.getValue("a").tilPerioder().map { it.verdi })
+    }
+}


### PR DESCRIPTION
### Favro: [NAV-29939](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-29939)

Flytter domeneuavhengige extension-funksjoner for `Tidslinje`/`Periode` fra familie-ba-sak til felles-biblioteket.

Nye/utvidede funksjoner i `no.nav.familie.tidslinje` / `no.nav.familie.tidslinje.utvidelser`:

- `kombinerUtenNullMed`, `kombinerUtenNull`, `kombinerUtenNullOgIkkeTom`, `kombinerKunVerdiMed`, `kombinerMedNullable`, `erIkkeTom`, `harOverlappMed`, `harIkkeOverlappMed`
- `joinIkkeNull`
- `filtrerIkkeNull(predikat)`, `filtrerMed`, `filtrerHverKunVerdi`
- `mapIkkeNull`
- `beskjær`, `beskjærFraOgMed`, `beskjærTilOgMed`, `beskjærTilOgMedEtter`, `forlengFremtidTilUendelig`
- `tilMåned`, `tilMånedFraMånedsskifte(IkkeNull)`, `forlengTidslinjeMedEnMåned`
- `minus`/`sum`/`rundAvTilHeltall` for `Tidslinje<BigDecimal>`
- `minsteAvHver`
- `splittPerMåned`, `erMinst12Måneder`, `erMinst6Måneder`, `erMinst12MånederMedNullTomSomUendelig`

`zipMedNeste`/`ZipPadding` ble **ikke** flyttet siden det allerede fantes identisk i felles fra før.

Alle nye funksjoner har tilhørende enhetstester.