### PR TITLE
Tilgangsmaskin-klient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
         <module>util</module>
         <module>kafka</module>
         <module>valutakurs-klient</module>
+        <module>tilgangsmaskin-klient</module>
         <module>unleash</module>
         <module>metrikker</module>
         <module>token-klient</module>
@@ -185,6 +186,11 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>valutakurs-klient</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>tilgangsmaskin-klient</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/tilgangsmaskin-klient/README.md
+++ b/tilgangsmaskin-klient/README.md
@@ -42,14 +42,16 @@ Body er en liste med `brukerId` og ønsket regeltype:
 
 ### Regeltyper
 
-| Regeltype            | Regler som kjøres                                                                       |
-|----------------------|------------------------------------------------------------------------------------------|
-| `KJERNE_REGELTYPE`   | Adressebeskyttelse (fortrolig/strengt fortrolig), skjerming (egen ansatt) og habilitet    |
-| `KOMPLETT_REGELTYPE` | Kjernereglene **pluss** geografisk tilgang, vergemål, avdød, utenlandsk/ukjent bosted     |
+| Regeltype               | Regler som kjøres                                                                       |
+|-------------------------|------------------------------------------------------------------------------------------|
+| `KJERNE_REGELTYPE`      | Adressebeskyttelse (fortrolig/strengt fortrolig), skjerming (egen ansatt) og habilitet    |
+| `OVERSTYRBAR_REGELTYPE` | Kun de overstyrbare reglene: geografisk tilgang, vergemål, avdød, utenlandsk/ukjent bosted |
+| `KOMPLETT_REGELTYPE`    | Kjernereglene **pluss** de overstyrbare reglene                                           |
 
 Klienten bruker `KJERNE_REGELTYPE` som default. Merk at avvisningskodene `AVVIST_GEOGRAFISK`,
 `AVVIST_VERGEMÅL`, `AVVIST_AVDØD`, `AVVIST_PERSON_UTLAND` og `AVVIST_UKJENT_BOSTED` **kun kan
-forekomme med `KOMPLETT_REGELTYPE`**. Velg regeltype bevisst i konsumenten.
+forekomme med `KOMPLETT_REGELTYPE` eller `OVERSTYRBAR_REGELTYPE`**. Velg regeltype bevisst i
+konsumenten.
 
 ### Respons
 
@@ -96,11 +98,11 @@ class ApplicationConfig
 Konfigurasjonen krever:
 
 * Miljøvariabelen `TILGANGSMASKIN_API_URL`, f.eks. `http://populasjonstilgangskontroll.tilgangsmaskin`
-* En `RestClient`-bønne kvalifisert med navnet i `TilgangsmaskinKlientConfig.TILGANGSMASKIN_REST_CLIENT`
+* En `RestClient`-bønne kvalifisert med navnet i `TilgangsmaskinKlientConfig.TILGANGSMASKIN_OBO_REST_CLIENT`.
 
 ```kotlin
-@Bean(TilgangsmaskinKlientConfig.TILGANGSMASKIN_REST_CLIENT)
-fun tilgangsmaskinRestClient(
+@Bean(TilgangsmaskinKlientConfig.TILGANGSMASKIN_OBO_REST_CLIENT)
+fun tilgangsmaskinOboRestClient(
     @Value("\${TILGANGSMASKIN_SCOPE}") scope: String,
 ): RestClient = entraIDRestClientFactory.lagOboRestKlient(scope) { SikkerhetContext.hentJwt()?.tokenValue }
 ```
@@ -125,14 +127,17 @@ val resultater = tilgangsmaskinKlient.sjekkTilgangTilPersoner(personIdenter)
 
 * **Chunking.** Tilgangsmaskinen svarer `413` på mer enn 1000 brukerId-er per kall
   (`MAKS_ANTALL_IDENTER_PER_KALL`). Klienten deler opp og slår sammen resultatene.
-* **Validering.** Duplikate identer fjernes, og blanke identer filtreres bort — tjenesten svarer `400`
-  på blank `brukerId`. Tom liste gir tom liste tilbake uten kall.
+* **Validering.** Identene sendes inn som `Set`, så duplikater er utelukket allerede i signaturen.
+  Blanke identer filtreres bort — tjenesten svarer `400` på blank `brukerId`. Tomt sett gir tom
+  liste tilbake uten kall.
 * **Fail-closed.** Svarer ikke Tilgangsmaskinen for en ident, returneres et resultat med
   `harTilgang = false` framfor at identen mangler i svaret. Konsumenten får alltid ett resultat per
   gyldig ident, og kan ikke ved et uhell tolke manglende svar som tilgang.
 * **Feil.** Alle feil pakkes i `TilgangsmaskinException`. Meldingen inneholder **kun** statuskode eller
   exception-type, fordi responsbodyen kan inneholde personidenter og ofte blir eksponert videre av
-  konsumenten. Detaljene ligger i `cause`.
+  konsumenten. Detaljene ligger i `cause`, og `httpStatus` er satt når feilen kom fra et HTTP-svar,
+  slik at konsumenten kan skille klientfeil (4xx) fra serverfeil (5xx).
 
-Klienten logger ikke selv — den vet ikke om konsumenten har secureLog. Konsumenten er ansvarlig for å
+Klienten logger ikke selv — den vet ikke om konsumenten har secureLog. Eneste unntak er en `WARN` ved
+ukjent avvisningskode; den inneholder kun koden, aldri personidenter. Konsumenten er ansvarlig for å
 logge avvisninger, og bør ta med `traceId`.

--- a/tilgangsmaskin-klient/README.md
+++ b/tilgangsmaskin-klient/README.md
@@ -1,6 +1,6 @@
 # tilgangsmaskin-klient
 
-Klient for å sjekke om en saksbehandler har tilgang til én eller flere personer i Tilgangsmaskinen
+Klient for å sjekke om en saksbehandler har tilgang til én eller flere personer gjennom Tilgangsmaskinen
 (applikasjonen `populasjonstilgangskontroll` i namespacet `tilgangsmaskin`).
 
 Tilgangsmaskinen er tiltenkt å erstatte tilgangssjekken som tidligere lå i `familie-integrasjoner`

--- a/tilgangsmaskin-klient/README.md
+++ b/tilgangsmaskin-klient/README.md
@@ -1,0 +1,138 @@
+# tilgangsmaskin-klient
+
+Klient for å sjekke om en saksbehandler har tilgang til én eller flere personer i Tilgangsmaskinen
+(applikasjonen `populasjonstilgangskontroll` i namespacet `tilgangsmaskin`).
+
+Tilgangsmaskinen er tiltenkt å erstatte tilgangssjekken som tidligere lå i `familie-integrasjoner`
+(`POST /tilgang/v2/personer`).
+
+## Dokumentasjon for tjenesten
+
+| Hva                | Lenke                                                          |
+|--------------------|----------------------------------------------------------------|
+| Confluence         | https://confluence.adeo.no/x/JhR8JQ                            |
+| Swagger (prod)     | https://tilgangsmaskin.intern.nav.no/swagger-ui/index.html      |
+| Swagger (dev)      | https://tilgangsmaskin.intern.dev.nav.no/swagger-ui/index.html  |
+| Kildekode          | https://github.com/navikt/populasjonstilgangskontroll          |
+| Slack              | #team-tilgangsmaskinen-værsågod                                |
+
+## Endepunktet klienten bruker
+
+Klienten bruker kun bulk-endepunktet, også for oppslag på én person:
+
+```
+POST {TILGANGSMASKIN_API_URL}/api/v1/bulk/obo
+```
+
+`obo` betyr *on-behalf-of*: Tilgangsmaskinen leser hvilken ansatt det spørres på vegne av fra
+`NAVident` i tokenet. **Endepunktet krever et OBO-token** — et maskin-til-maskin-token blir avvist av
+tjenestens `TokenTypeGuard`. Konsumenten må derfor levere en `RestClient` som veksler inn
+saksbehandlerens token.
+
+### Request
+
+Body er en liste med `brukerId` og ønsket regeltype:
+
+```json
+[
+  { "brukerId": "12345678910", "type": "KJERNE_REGELTYPE" },
+  { "brukerId": "10987654321", "type": "KJERNE_REGELTYPE" }
+]
+```
+
+### Regeltyper
+
+| Regeltype            | Regler som kjøres                                                                       |
+|----------------------|------------------------------------------------------------------------------------------|
+| `KJERNE_REGELTYPE`   | Adressebeskyttelse (fortrolig/strengt fortrolig), skjerming (egen ansatt) og habilitet    |
+| `KOMPLETT_REGELTYPE` | Kjernereglene **pluss** geografisk tilgang, vergemål, avdød, utenlandsk/ukjent bosted     |
+
+Klienten bruker `KJERNE_REGELTYPE` som default. Merk at avvisningskodene `AVVIST_GEOGRAFISK`,
+`AVVIST_VERGEMÅL`, `AVVIST_AVDØD`, `AVVIST_PERSON_UTLAND` og `AVVIST_UKJENT_BOSTED` **kun kan
+forekomme med `KOMPLETT_REGELTYPE`**. Velg regeltype bevisst i konsumenten.
+
+### Respons
+
+Statuskoden på selve kallet er `207 Multi-Status`. Utfallet per person ligger i `status`:
+
+```json
+{
+  "ansattId": "Z999999",
+  "resultater": [
+    { "brukerId": "12345678910", "status": 204 },
+    {
+      "brukerId": "10987654321",
+      "status": 403,
+      "detaljer": {
+        "title": "AVVIST_SKJERMING",
+        "begrunnelse": "Bruker er skjermet",
+        "traceId": "0af7651916cd43dd8448eb211c80319c",
+        "kanOverstyres": true
+      }
+    }
+  ]
+}
+```
+
+| `status` | Betydning                          |
+|----------|------------------------------------|
+| `204`    | Tilgang                            |
+| `403`    | Avvist, se `detaljer`              |
+| `404`    | Ukjent bruker (ingen tilgang)      |
+
+Klienten mapper dette til `TilgangsmaskinResultat`, der **kun `204` gir `harTilgang = true`**.
+`detaljer.title` mappes til `Avvisningskode` via navnelikhet; ukjente koder blir `UKJENT` slik at
+klienten tåler at Tilgangsmaskinen innfører nye koder.
+
+## Bruk
+
+Importer konfigurasjonen i app-konfigurasjonen din:
+
+```kotlin
+@Import(TilgangsmaskinKlientConfig::class)
+class ApplicationConfig
+```
+
+Konfigurasjonen krever:
+
+* Miljøvariabelen `TILGANGSMASKIN_API_URL`, f.eks. `http://populasjonstilgangskontroll.tilgangsmaskin`
+* En `RestClient`-bønne kvalifisert med navnet i `TilgangsmaskinKlientConfig.TILGANGSMASKIN_REST_CLIENT`
+
+```kotlin
+@Bean(TilgangsmaskinKlientConfig.TILGANGSMASKIN_REST_CLIENT)
+fun tilgangsmaskinRestClient(
+    @Value("\${TILGANGSMASKIN_SCOPE}") scope: String,
+): RestClient = entraIDRestClientFactory.lagOboRestKlient(scope) { SikkerhetContext.hentJwt()?.tokenValue }
+```
+
+Appen må i tillegg ha `outbound`-tilgang til tjenesten i `nais.yaml`:
+
+```yaml
+outbound:
+  rules:
+    - application: populasjonstilgangskontroll
+      namespace: tilgangsmaskin
+      cluster: prod-gcp # eller dev-gcp
+```
+
+Deretter kan `TilgangsmaskinKlient` injiseres:
+
+```kotlin
+val resultater = tilgangsmaskinKlient.sjekkTilgangTilPersoner(personIdenter)
+```
+
+## Det klienten håndterer for deg
+
+* **Chunking.** Tilgangsmaskinen svarer `413` på mer enn 1000 brukerId-er per kall
+  (`MAKS_ANTALL_IDENTER_PER_KALL`). Klienten deler opp og slår sammen resultatene.
+* **Validering.** Duplikate identer fjernes, og blanke identer filtreres bort — tjenesten svarer `400`
+  på blank `brukerId`. Tom liste gir tom liste tilbake uten kall.
+* **Fail-closed.** Svarer ikke Tilgangsmaskinen for en ident, returneres et resultat med
+  `harTilgang = false` framfor at identen mangler i svaret. Konsumenten får alltid ett resultat per
+  gyldig ident, og kan ikke ved et uhell tolke manglende svar som tilgang.
+* **Feil.** Alle feil pakkes i `TilgangsmaskinException`. Meldingen inneholder **kun** statuskode eller
+  exception-type, fordi responsbodyen kan inneholde personidenter og ofte blir eksponert videre av
+  konsumenten. Detaljene ligger i `cause`.
+
+Klienten logger ikke selv — den vet ikke om konsumenten har secureLog. Konsumenten er ansvarlig for å
+logge avvisninger, og bør ta med `traceId`.

--- a/tilgangsmaskin-klient/pom.xml
+++ b/tilgangsmaskin-klient/pom.xml
@@ -42,11 +42,6 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-
         <!--TEST-->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/tilgangsmaskin-klient/pom.xml
+++ b/tilgangsmaskin-klient/pom.xml
@@ -42,6 +42,10 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
         <!--TEST-->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/tilgangsmaskin-klient/pom.xml
+++ b/tilgangsmaskin-klient/pom.xml
@@ -39,6 +39,10 @@
             <artifactId>spring-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
@@ -52,6 +56,11 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/tilgangsmaskin-klient/pom.xml
+++ b/tilgangsmaskin-klient/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>no.nav.familie.felles</groupId>
+        <artifactId>felles</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+    </parent>
+
+    <artifactId>tilgangsmaskin-klient</artifactId>
+    <version>${revision}${sha1}${changelist}</version>
+    <name>Felles - Tilgangsmaskin-klient</name>
+    <description>Klient for å sjekke tilgang til personer i Tilgangsmaskinen (populasjonstilgangskontroll)</description>
+
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>tools.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!--TEST-->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>src/test/kotlin</testSourceDirectory>
+
+        <plugins>
+            <plugin>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-maven-allopen</artifactId>
+                        <version>${kotlin.version}</version>
+                    </dependency>
+                </dependencies>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <jvmTarget>17</jvmTarget>
+                    <compilerPlugins>
+                        <plugin>spring</plugin>
+                    </compilerPlugins>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tilgangsmaskin-klient/src/main/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinDto.kt
+++ b/tilgangsmaskin-klient/src/main/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinDto.kt
@@ -2,13 +2,6 @@ package no.nav.familie.tilgangsmaskin
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
-/**
- * Regelsett i Tilgangsmaskinen.
- *
- * [KJERNE_REGELTYPE] dekker kode 6, kode 7, §19, skjerming (egen ansatt), egne data og egen familie.
- * [KOMPLETT_REGELTYPE] legger i tillegg på de overstyrbare reglene for geografi/enhet, ukjent bosted,
- * utland, avdød og vergemål.
- */
 enum class Regeltype {
     KJERNE_REGELTYPE,
     KOMPLETT_REGELTYPE,
@@ -19,14 +12,6 @@ data class BrukerIdOgRegelsettDto(
     val type: Regeltype,
 )
 
-/**
- * NB: [resultater] har bevisst ingen defaultverdi.
- *
- * Får alle konstruktørparametrene i en Kotlin data class en defaultverdi, genererer Kotlin en syntetisk
- * no-arg-konstruktør. Jackson foretrekker den dersom Kotlin-modulen ikke er registrert på ObjectMapperen,
- * og fyller da aldri feltene — vi ville fått en tom resultatliste uten feilmelding, og dermed nektet
- * tilgang for alle. Uten defaultverdi feiler deserialiseringen høylytt i stedet for stille.
- */
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class TilgangsmaskinBulkResponsDto(
     val resultater: List<TilgangsmaskinBulkResultatDto>,
@@ -40,11 +25,8 @@ data class TilgangsmaskinBulkResultatDto(
     val detaljer: TilgangsmaskinAvvisningDto? = null,
 )
 
-// title har bevisst ingen defaultverdi — se forklaringen på TilgangsmaskinBulkResponsDto.
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class TilgangsmaskinAvvisningDto(
-    // title leses som String, ikke enum. Tilgangsmaskinen kan innføre nye avvisningskoder, og en ukjent
-    // verdi skal ikke føre til at hele bulk-responsen feiler å deserialisere.
     val title: String?,
     val begrunnelse: String? = null,
     val traceId: String? = null,
@@ -72,13 +54,6 @@ enum class Avvisningskode {
     }
 }
 
-/**
- * Resultat av tilgangssjekk for én person.
- *
- * [avvisningskode] er null når tilgang er innvilget, slik at «innvilget» og «avvist av ukjent grunn» ikke
- * kan forveksles. [kanOverstyres] er bevisst tatt vare på: uten den kan ikke konsumenten skille avvisninger
- * som kan overstyres (geografi/enhet) fra de som ikke kan det (kode 6/7, skjerming).
- */
 data class TilgangsmaskinResultat(
     val personIdent: String,
     val harTilgang: Boolean,

--- a/tilgangsmaskin-klient/src/main/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinDto.kt
+++ b/tilgangsmaskin-klient/src/main/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinDto.kt
@@ -10,7 +10,9 @@ enum class Regeltype {
 data class BrukerIdOgRegelsettDto(
     val brukerId: String,
     val type: Regeltype,
-)
+) {
+    override fun toString(): String = "BrukerIdOgRegelsettDto(brukerId=${brukerId.maskerIdent()}, type=$type)"
+}
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class TilgangsmaskinBulkResponsDto(
@@ -23,7 +25,10 @@ data class TilgangsmaskinBulkResultatDto(
     val brukerId: String,
     val status: Int,
     val detaljer: TilgangsmaskinAvvisningDto? = null,
-)
+) {
+    override fun toString(): String =
+        "TilgangsmaskinBulkResultatDto(brukerId=${brukerId.maskerIdent()}, status=$status, detaljer=$detaljer)"
+}
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class TilgangsmaskinAvvisningDto(
@@ -62,7 +67,13 @@ data class TilgangsmaskinResultat(
     val begrunnelse: String? = null,
     val traceId: String? = null,
     val kanOverstyres: Boolean = false,
-)
+) {
+    override fun toString(): String =
+        "TilgangsmaskinResultat(personIdent=${personIdent.maskerIdent()}, harTilgang=$harTilgang, httpStatus=$httpStatus, " +
+            "avvisningskode=$avvisningskode, begrunnelse=$begrunnelse, traceId=$traceId, kanOverstyres=$kanOverstyres)"
+}
+
+private fun String.maskerIdent(): String = "*".repeat(length)
 
 class TilgangsmaskinException(
     message: String,

--- a/tilgangsmaskin-klient/src/main/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinDto.kt
+++ b/tilgangsmaskin-klient/src/main/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinDto.kt
@@ -1,0 +1,95 @@
+package no.nav.familie.tilgangsmaskin
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+/**
+ * Regelsett i Tilgangsmaskinen.
+ *
+ * [KJERNE_REGELTYPE] dekker kode 6, kode 7, §19, skjerming (egen ansatt), egne data og egen familie.
+ * [KOMPLETT_REGELTYPE] legger i tillegg på de overstyrbare reglene for geografi/enhet, ukjent bosted,
+ * utland, avdød og vergemål.
+ */
+enum class Regeltype {
+    KJERNE_REGELTYPE,
+    KOMPLETT_REGELTYPE,
+}
+
+data class BrukerIdOgRegelsettDto(
+    val brukerId: String,
+    val type: Regeltype,
+)
+
+/**
+ * NB: [resultater] har bevisst ingen defaultverdi.
+ *
+ * Får alle konstruktørparametrene i en Kotlin data class en defaultverdi, genererer Kotlin en syntetisk
+ * no-arg-konstruktør. Jackson foretrekker den dersom Kotlin-modulen ikke er registrert på ObjectMapperen,
+ * og fyller da aldri feltene — vi ville fått en tom resultatliste uten feilmelding, og dermed nektet
+ * tilgang for alle. Uten defaultverdi feiler deserialiseringen høylytt i stedet for stille.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class TilgangsmaskinBulkResponsDto(
+    val resultater: List<TilgangsmaskinBulkResultatDto>,
+    val ansattId: String? = null,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class TilgangsmaskinBulkResultatDto(
+    val brukerId: String,
+    val status: Int,
+    val detaljer: TilgangsmaskinAvvisningDto? = null,
+)
+
+// title har bevisst ingen defaultverdi — se forklaringen på TilgangsmaskinBulkResponsDto.
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class TilgangsmaskinAvvisningDto(
+    // title leses som String, ikke enum. Tilgangsmaskinen kan innføre nye avvisningskoder, og en ukjent
+    // verdi skal ikke føre til at hele bulk-responsen feiler å deserialisere.
+    val title: String?,
+    val begrunnelse: String? = null,
+    val traceId: String? = null,
+    val kanOverstyres: Boolean = false,
+) {
+    fun avvisningskode(): Avvisningskode = Avvisningskode.fraTitle(title)
+}
+
+enum class Avvisningskode {
+    AVVIST_STRENGT_FORTROLIG_ADRESSE,
+    AVVIST_STRENGT_FORTROLIG_UTLAND,
+    AVVIST_AVDØD,
+    AVVIST_VERGEMÅL,
+    AVVIST_PERSON_UTLAND,
+    AVVIST_SKJERMING,
+    AVVIST_FORTROLIG_ADRESSE,
+    AVVIST_UKJENT_BOSTED,
+    AVVIST_GEOGRAFISK,
+    AVVIST_HABILITET,
+    UKJENT,
+    ;
+
+    companion object {
+        fun fraTitle(title: String?): Avvisningskode = entries.firstOrNull { it.name == title } ?: UKJENT
+    }
+}
+
+/**
+ * Resultat av tilgangssjekk for én person.
+ *
+ * [avvisningskode] er null når tilgang er innvilget, slik at «innvilget» og «avvist av ukjent grunn» ikke
+ * kan forveksles. [kanOverstyres] er bevisst tatt vare på: uten den kan ikke konsumenten skille avvisninger
+ * som kan overstyres (geografi/enhet) fra de som ikke kan det (kode 6/7, skjerming).
+ */
+data class TilgangsmaskinResultat(
+    val personIdent: String,
+    val harTilgang: Boolean,
+    val httpStatus: Int,
+    val avvisningskode: Avvisningskode? = null,
+    val begrunnelse: String? = null,
+    val traceId: String? = null,
+    val kanOverstyres: Boolean = false,
+)
+
+class TilgangsmaskinException(
+    message: String,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)

--- a/tilgangsmaskin-klient/src/main/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinDto.kt
+++ b/tilgangsmaskin-klient/src/main/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinDto.kt
@@ -1,10 +1,12 @@
 package no.nav.familie.tilgangsmaskin
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import org.slf4j.LoggerFactory
 
 enum class Regeltype {
     KJERNE_REGELTYPE,
     KOMPLETT_REGELTYPE,
+    OVERSTYRBAR_REGELTYPE,
 }
 
 data class BrukerIdOgRegelsettDto(
@@ -55,7 +57,15 @@ enum class Avvisningskode {
     ;
 
     companion object {
-        fun fraTitle(title: String?): Avvisningskode = entries.firstOrNull { it.name == title } ?: UKJENT
+        private val logger = LoggerFactory.getLogger(Avvisningskode::class.java)
+
+        fun fraTitle(title: String?): Avvisningskode {
+            val avvisningskode = entries.firstOrNull { it.name == title }
+            if (avvisningskode == null) {
+                logger.warn("Ukjent avvisningskode fra Tilgangsmaskinen: \"$title\"")
+            }
+            return avvisningskode ?: UKJENT
+        }
     }
 }
 
@@ -78,4 +88,6 @@ private fun String.maskerIdent(): String = "*".repeat(length)
 class TilgangsmaskinException(
     message: String,
     cause: Throwable? = null,
+    // Satt når feilen kom fra et HTTP-svar, slik at konsumenten kan skille klientfeil (4xx) fra serverfeil (5xx).
+    val httpStatus: Int? = null,
 ) : RuntimeException(message, cause)

--- a/tilgangsmaskin-klient/src/main/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinKlient.kt
+++ b/tilgangsmaskin-klient/src/main/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinKlient.kt
@@ -1,22 +1,12 @@
 package no.nav.familie.tilgangsmaskin
 
-import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.body
 import org.springframework.web.util.UriComponentsBuilder
 import java.net.URI
 
-/**
- * Klient mot Tilgangsmaskinen (populasjonstilgangskontroll).
- *
- * Bruker bulk-endepunktet med on-behalf-of-token, slik at NAV-identen til innlogget saksbehandler hentes
- * fra tokenet. Kallet kan derfor kun gjøres i saksbehandlerkontekst — i systemkontekst finnes det ingen
- * ansatt å sjekke tilgang for, og konsumenten må håndtere det selv før den kaller klienten.
- *
- * Konsumenten er ansvarlig for å sende inn en [RestClient] som legger på et OBO-token mot Tilgangsmaskinen
- * sitt scope. Klienten eier protokollen, ikke autentiseringen.
- */
 open class TilgangsmaskinKlient(
     tilgangsmaskinUri: URI,
     private val restClient: RestClient,
@@ -28,25 +18,12 @@ open class TilgangsmaskinKlient(
             .build()
             .toUri()
 
-    /**
-     * Sjekker tilgang til [personIdenter].
-     *
-     * Returnerer ett resultat per element i [personIdenter], i samme rekkefølge. Svarer ikke Tilgangsmaskinen
-     * for en ident, nektes tilgang — vi skal aldri gi tilgang basert på et ufullstendig svar.
-     *
-     * Tomme identer sendes ikke videre. Tilgangsmaskinen avviser hele forespørselen med 400 hvis én eneste
-     * brukerId er tom, og da ville én dårlig ident nektet tilgang til alle de andre i samme bolk.
-     *
-     * Kaster [TilgangsmaskinException] hvis kallet feiler. Da returneres ingen resultater i det hele tatt,
-     * og kalleren må behandle unntaket som manglende tilgang.
-     */
     open fun sjekkTilgangTilPersoner(
         personIdenter: List<String>,
         regeltype: Regeltype = Regeltype.KJERNE_REGELTYPE,
     ): List<TilgangsmaskinResultat> {
-        if (personIdenter.isEmpty()) return emptyList()
-
         val gyldigeIdenter = personIdenter.distinct().filter { it.isNotBlank() }
+        if (gyldigeIdenter.isEmpty()) return emptyList()
 
         val resultaterPerIdent =
             gyldigeIdenter
@@ -54,11 +31,7 @@ open class TilgangsmaskinKlient(
                 .flatMap { sjekkTilgangTilPersonerIBolk(it, regeltype) }
                 .associateBy { it.personIdent }
 
-        return personIdenter
-            .map { personIdent ->
-                resultaterPerIdent[personIdent]
-                    ?: if (personIdent.isBlank()) ugyldigIdent(personIdent) else manglendeSvar(personIdent)
-            }.also { loggAvvisninger(it) }
+        return gyldigeIdenter.map { resultaterPerIdent[it] ?: manglendeSvar(it) }
     }
 
     private fun sjekkTilgangTilPersonerIBolk(
@@ -70,17 +43,16 @@ open class TilgangsmaskinKlient(
                 restClient
                     .post()
                     .uri(bulkUri)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
                     .body(personIdenter.map { BrukerIdOgRegelsettDto(brukerId = it, type = regeltype) })
                     .retrieve()
                     .body<TilgangsmaskinBulkResponsDto>()
-                    ?: throw TilgangsmaskinException("Fikk tomt svar fra Tilgangsmaskinen")
-            } catch (tilgangsmaskinException: TilgangsmaskinException) {
-                throw tilgangsmaskinException
             } catch (exception: Exception) {
                 throw TilgangsmaskinException("Feil ved kall mot Tilgangsmaskinen: ${exception.message}", exception)
             }
 
-        return respons.resultater.map { it.tilResultat() }
+        return respons?.resultater?.map { it.tilResultat() } ?: throw TilgangsmaskinException("Fikk tomt svar fra Tilgangsmaskinen")
     }
 
     private fun manglendeSvar(personIdent: String) =
@@ -92,29 +64,9 @@ open class TilgangsmaskinKlient(
             begrunnelse = "Fikk ikke svar fra Tilgangsmaskinen for personen",
         )
 
-    private fun ugyldigIdent(personIdent: String) =
-        TilgangsmaskinResultat(
-            personIdent = personIdent,
-            harTilgang = false,
-            httpStatus = HttpStatus.BAD_REQUEST.value(),
-            avvisningskode = Avvisningskode.UKJENT,
-            begrunnelse = "Personidenten er tom og kan ikke sjekkes mot Tilgangsmaskinen",
-        )
-
-    private fun loggAvvisninger(resultater: List<TilgangsmaskinResultat>) {
-        val avviste = resultater.filterNot { it.harTilgang }
-        if (avviste.isEmpty()) return
-
-        logger.info(
-            "Tilgangsmaskinen avviste tilgang til {} person(er). Avvisningskoder: {}. TraceId: {}",
-            avviste.size,
-            avviste.mapNotNull { it.avvisningskode }.distinct(),
-            avviste.mapNotNull { it.traceId }.distinct(),
-        )
-    }
-
     private fun TilgangsmaskinBulkResultatDto.tilResultat(): TilgangsmaskinResultat {
         val harTilgang = status == HttpStatus.NO_CONTENT.value()
+
         return TilgangsmaskinResultat(
             personIdent = brukerId,
             harTilgang = harTilgang,
@@ -127,8 +79,6 @@ open class TilgangsmaskinKlient(
     }
 
     companion object {
-        private val logger = LoggerFactory.getLogger(TilgangsmaskinKlient::class.java)
-
         // Tilgangsmaskinen tillater maksimalt 1000 brukerId-er per bulk-forespørsel, og svarer 413 over det.
         const val MAKS_ANTALL_IDENTER_PER_KALL = 1000
     }

--- a/tilgangsmaskin-klient/src/main/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinKlient.kt
+++ b/tilgangsmaskin-klient/src/main/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinKlient.kt
@@ -20,10 +20,10 @@ open class TilgangsmaskinKlient(
             .toUri()
 
     open fun sjekkTilgangTilPersoner(
-        personIdenter: List<String>,
+        personIdenter: Set<String>,
         regeltype: Regeltype = Regeltype.KJERNE_REGELTYPE,
     ): List<TilgangsmaskinResultat> {
-        val gyldigeIdenter = personIdenter.distinct().filter { it.isNotBlank() }
+        val gyldigeIdenter = personIdenter.filter { it.isNotBlank() }
         if (gyldigeIdenter.isEmpty()) return emptyList()
 
         val resultaterPerIdent =
@@ -50,7 +50,11 @@ open class TilgangsmaskinKlient(
                     .retrieve()
                     .body<TilgangsmaskinBulkResponsDto>()
             } catch (exception: Exception) {
-                throw TilgangsmaskinException(feilmelding(exception), exception)
+                throw TilgangsmaskinException(
+                    message = feilmelding(exception),
+                    cause = exception,
+                    httpStatus = (exception as? RestClientResponseException)?.statusCode?.value(),
+                )
             }
 
         return respons?.resultater?.map { it.tilResultat() } ?: throw TilgangsmaskinException("Fikk tomt svar fra Tilgangsmaskinen")

--- a/tilgangsmaskin-klient/src/main/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinKlient.kt
+++ b/tilgangsmaskin-klient/src/main/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinKlient.kt
@@ -1,0 +1,135 @@
+package no.nav.familie.tilgangsmaskin
+
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.body
+import org.springframework.web.util.UriComponentsBuilder
+import java.net.URI
+
+/**
+ * Klient mot Tilgangsmaskinen (populasjonstilgangskontroll).
+ *
+ * Bruker bulk-endepunktet med on-behalf-of-token, slik at NAV-identen til innlogget saksbehandler hentes
+ * fra tokenet. Kallet kan derfor kun gjøres i saksbehandlerkontekst — i systemkontekst finnes det ingen
+ * ansatt å sjekke tilgang for, og konsumenten må håndtere det selv før den kaller klienten.
+ *
+ * Konsumenten er ansvarlig for å sende inn en [RestClient] som legger på et OBO-token mot Tilgangsmaskinen
+ * sitt scope. Klienten eier protokollen, ikke autentiseringen.
+ */
+open class TilgangsmaskinKlient(
+    tilgangsmaskinUri: URI,
+    private val restClient: RestClient,
+) {
+    private val bulkUri: URI =
+        UriComponentsBuilder
+            .fromUri(tilgangsmaskinUri)
+            .pathSegment("api", "v1", "bulk", "obo")
+            .build()
+            .toUri()
+
+    /**
+     * Sjekker tilgang til [personIdenter].
+     *
+     * Returnerer ett resultat per element i [personIdenter], i samme rekkefølge. Svarer ikke Tilgangsmaskinen
+     * for en ident, nektes tilgang — vi skal aldri gi tilgang basert på et ufullstendig svar.
+     *
+     * Tomme identer sendes ikke videre. Tilgangsmaskinen avviser hele forespørselen med 400 hvis én eneste
+     * brukerId er tom, og da ville én dårlig ident nektet tilgang til alle de andre i samme bolk.
+     *
+     * Kaster [TilgangsmaskinException] hvis kallet feiler. Da returneres ingen resultater i det hele tatt,
+     * og kalleren må behandle unntaket som manglende tilgang.
+     */
+    open fun sjekkTilgangTilPersoner(
+        personIdenter: List<String>,
+        regeltype: Regeltype = Regeltype.KJERNE_REGELTYPE,
+    ): List<TilgangsmaskinResultat> {
+        if (personIdenter.isEmpty()) return emptyList()
+
+        val gyldigeIdenter = personIdenter.distinct().filter { it.isNotBlank() }
+
+        val resultaterPerIdent =
+            gyldigeIdenter
+                .chunked(MAKS_ANTALL_IDENTER_PER_KALL)
+                .flatMap { sjekkTilgangTilPersonerIBolk(it, regeltype) }
+                .associateBy { it.personIdent }
+
+        return personIdenter
+            .map { personIdent ->
+                resultaterPerIdent[personIdent]
+                    ?: if (personIdent.isBlank()) ugyldigIdent(personIdent) else manglendeSvar(personIdent)
+            }.also { loggAvvisninger(it) }
+    }
+
+    private fun sjekkTilgangTilPersonerIBolk(
+        personIdenter: List<String>,
+        regeltype: Regeltype,
+    ): List<TilgangsmaskinResultat> {
+        val respons =
+            try {
+                restClient
+                    .post()
+                    .uri(bulkUri)
+                    .body(personIdenter.map { BrukerIdOgRegelsettDto(brukerId = it, type = regeltype) })
+                    .retrieve()
+                    .body<TilgangsmaskinBulkResponsDto>()
+                    ?: throw TilgangsmaskinException("Fikk tomt svar fra Tilgangsmaskinen")
+            } catch (tilgangsmaskinException: TilgangsmaskinException) {
+                throw tilgangsmaskinException
+            } catch (exception: Exception) {
+                throw TilgangsmaskinException("Feil ved kall mot Tilgangsmaskinen: ${exception.message}", exception)
+            }
+
+        return respons.resultater.map { it.tilResultat() }
+    }
+
+    private fun manglendeSvar(personIdent: String) =
+        TilgangsmaskinResultat(
+            personIdent = personIdent,
+            harTilgang = false,
+            httpStatus = HttpStatus.INTERNAL_SERVER_ERROR.value(),
+            avvisningskode = Avvisningskode.UKJENT,
+            begrunnelse = "Fikk ikke svar fra Tilgangsmaskinen for personen",
+        )
+
+    private fun ugyldigIdent(personIdent: String) =
+        TilgangsmaskinResultat(
+            personIdent = personIdent,
+            harTilgang = false,
+            httpStatus = HttpStatus.BAD_REQUEST.value(),
+            avvisningskode = Avvisningskode.UKJENT,
+            begrunnelse = "Personidenten er tom og kan ikke sjekkes mot Tilgangsmaskinen",
+        )
+
+    private fun loggAvvisninger(resultater: List<TilgangsmaskinResultat>) {
+        val avviste = resultater.filterNot { it.harTilgang }
+        if (avviste.isEmpty()) return
+
+        logger.info(
+            "Tilgangsmaskinen avviste tilgang til {} person(er). Avvisningskoder: {}. TraceId: {}",
+            avviste.size,
+            avviste.mapNotNull { it.avvisningskode }.distinct(),
+            avviste.mapNotNull { it.traceId }.distinct(),
+        )
+    }
+
+    private fun TilgangsmaskinBulkResultatDto.tilResultat(): TilgangsmaskinResultat {
+        val harTilgang = status == HttpStatus.NO_CONTENT.value()
+        return TilgangsmaskinResultat(
+            personIdent = brukerId,
+            harTilgang = harTilgang,
+            httpStatus = status,
+            avvisningskode = if (harTilgang) null else detaljer?.avvisningskode() ?: Avvisningskode.UKJENT,
+            begrunnelse = detaljer?.begrunnelse,
+            traceId = detaljer?.traceId,
+            kanOverstyres = detaljer?.kanOverstyres ?: false,
+        )
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(TilgangsmaskinKlient::class.java)
+
+        // Tilgangsmaskinen tillater maksimalt 1000 brukerId-er per bulk-forespørsel, og svarer 413 over det.
+        const val MAKS_ANTALL_IDENTER_PER_KALL = 1000
+    }
+}

--- a/tilgangsmaskin-klient/src/main/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinKlient.kt
+++ b/tilgangsmaskin-klient/src/main/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinKlient.kt
@@ -3,6 +3,7 @@ package no.nav.familie.tilgangsmaskin
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.web.client.RestClient
+import org.springframework.web.client.RestClientResponseException
 import org.springframework.web.client.body
 import org.springframework.web.util.UriComponentsBuilder
 import java.net.URI
@@ -49,11 +50,19 @@ open class TilgangsmaskinKlient(
                     .retrieve()
                     .body<TilgangsmaskinBulkResponsDto>()
             } catch (exception: Exception) {
-                throw TilgangsmaskinException("Feil ved kall mot Tilgangsmaskinen: ${exception.message}", exception)
+                throw TilgangsmaskinException(feilmelding(exception), exception)
             }
 
         return respons?.resultater?.map { it.tilResultat() } ?: throw TilgangsmaskinException("Fikk tomt svar fra Tilgangsmaskinen")
     }
+
+    // Responsbodyen kan inneholde personidenter, og meldingen kan bli eksponert videre av konsumenten.
+    // Derfor tar vi kun med statuskoden her; detaljene ligger i cause.
+    private fun feilmelding(exception: Exception): String =
+        when (exception) {
+            is RestClientResponseException -> "Feil ved kall mot Tilgangsmaskinen: HTTP ${exception.statusCode.value()}"
+            else -> "Feil ved kall mot Tilgangsmaskinen: ${exception.javaClass.simpleName}"
+        }
 
     private fun manglendeSvar(personIdent: String) =
         TilgangsmaskinResultat(

--- a/tilgangsmaskin-klient/src/main/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinKlientConfig.kt
+++ b/tilgangsmaskin-klient/src/main/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinKlientConfig.kt
@@ -12,10 +12,10 @@ class TilgangsmaskinKlientConfig {
     @Bean
     fun tilgangsmaskinKlient(
         @Value("\${TILGANGSMASKIN_API_URL}") tilgangsmaskinUri: URI,
-        @Qualifier(TILGANGSMASKIN_REST_CLIENT) restClient: RestClient,
+        @Qualifier(TILGANGSMASKIN_OBO_REST_CLIENT) restClient: RestClient,
     ): TilgangsmaskinKlient = TilgangsmaskinKlient(tilgangsmaskinUri, restClient)
 
     companion object {
-        const val TILGANGSMASKIN_REST_CLIENT = "tilgangsmaskinRestClient"
+        const val TILGANGSMASKIN_OBO_REST_CLIENT = "tilgangsmaskinOboRestClient"
     }
 }

--- a/tilgangsmaskin-klient/src/main/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinKlientConfig.kt
+++ b/tilgangsmaskin-klient/src/main/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinKlientConfig.kt
@@ -1,0 +1,21 @@
+package no.nav.familie.tilgangsmaskin
+
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.client.RestClient
+import java.net.URI
+
+@Configuration
+class TilgangsmaskinKlientConfig {
+    @Bean
+    fun tilgangsmaskinKlient(
+        @Value("\${TILGANGSMASKIN_API_URL}") tilgangsmaskinUri: URI,
+        @Qualifier(TILGANGSMASKIN_REST_CLIENT) restClient: RestClient,
+    ): TilgangsmaskinKlient = TilgangsmaskinKlient(tilgangsmaskinUri, restClient)
+
+    companion object {
+        const val TILGANGSMASKIN_REST_CLIENT = "tilgangsmaskinRestClient"
+    }
+}

--- a/tilgangsmaskin-klient/src/test/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinDtoTest.kt
+++ b/tilgangsmaskin-klient/src/test/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinDtoTest.kt
@@ -1,0 +1,84 @@
+package no.nav.familie.tilgangsmaskin
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class TilgangsmaskinDtoTest {
+    @Test
+    fun `toString på BrukerIdOgRegelsettDto skal ikke inneholde personidenten`() {
+        // Arrange
+        val dto = BrukerIdOgRegelsettDto(brukerId = PERSONIDENT, type = Regeltype.KJERNE_REGELTYPE)
+
+        // Act
+        val tekst = dto.toString()
+
+        // Assert
+        assertThat(tekst).doesNotContain(PERSONIDENT)
+        assertThat(tekst).contains("KJERNE_REGELTYPE")
+    }
+
+    @Test
+    fun `toString på TilgangsmaskinBulkResultatDto skal ikke inneholde personidenten`() {
+        // Arrange
+        val dto = TilgangsmaskinBulkResultatDto(brukerId = PERSONIDENT, status = 403)
+
+        // Act
+        val tekst = dto.toString()
+
+        // Assert
+        assertThat(tekst).doesNotContain(PERSONIDENT)
+        assertThat(tekst).contains("403")
+    }
+
+    @Test
+    fun `toString på TilgangsmaskinResultat skal ikke inneholde personidenten`() {
+        // Arrange
+        val resultat =
+            TilgangsmaskinResultat(
+                personIdent = PERSONIDENT,
+                harTilgang = false,
+                httpStatus = 403,
+                avvisningskode = Avvisningskode.AVVIST_SKJERMING,
+                traceId = "en-trace-id",
+            )
+
+        // Act
+        val tekst = resultat.toString()
+
+        // Assert
+        assertThat(tekst).doesNotContain(PERSONIDENT)
+        assertThat(tekst).contains("AVVIST_SKJERMING", "en-trace-id")
+    }
+
+    @Test
+    fun `toString på TilgangsmaskinBulkResponsDto skal ikke inneholde personidenten`() {
+        // Arrange
+        val respons =
+            TilgangsmaskinBulkResponsDto(
+                resultater = listOf(TilgangsmaskinBulkResultatDto(brukerId = PERSONIDENT, status = 204)),
+                ansattId = "Z999999",
+            )
+
+        // Act
+        val tekst = respons.toString()
+
+        // Assert
+        assertThat(tekst).doesNotContain(PERSONIDENT)
+    }
+
+    @Test
+    fun `maskering skal beholde lengden slik at man ser at verdien var satt`() {
+        // Arrange
+        val dto = BrukerIdOgRegelsettDto(brukerId = PERSONIDENT, type = Regeltype.KJERNE_REGELTYPE)
+
+        // Act
+        val tekst = dto.toString()
+
+        // Assert
+        assertThat(tekst).contains("*".repeat(PERSONIDENT.length))
+    }
+
+    companion object {
+        private const val PERSONIDENT = "12345678910"
+    }
+}

--- a/tilgangsmaskin-klient/src/test/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinKlientConfigTest.kt
+++ b/tilgangsmaskin-klient/src/test/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinKlientConfigTest.kt
@@ -1,0 +1,86 @@
+package no.nav.familie.tilgangsmaskin
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.env.MapPropertySource
+import org.springframework.web.client.RestClient
+
+class TilgangsmaskinKlientConfigTest {
+    private lateinit var wiremockServer: WireMockServer
+
+    @BeforeEach
+    fun setUp() {
+        wiremockServer = WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort())
+        wiremockServer.start()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        wiremockServer.stop()
+    }
+
+    @Test
+    fun `skal lage klient med den kvalifiserte RestClienten og url fra property`() {
+        // Arrange
+        wiremockServer.stubFor(
+            post(urlEqualTo("/api/v1/bulk/obo")).willReturn(
+                aResponse()
+                    .withStatus(207)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("""{ "resultater": [ { "brukerId": "12345678910", "status": 204 } ] }"""),
+            ),
+        )
+        val kontekst = AnnotationConfigApplicationContext()
+        kontekst.environment.propertySources.addFirst(
+            MapPropertySource("test", mapOf("TILGANGSMASKIN_API_URL" to wiremockServer.baseUrl())),
+        )
+        kontekst.register(RestClientTestConfig::class.java, TilgangsmaskinKlientConfig::class.java)
+        kontekst.refresh()
+
+        // Act
+        val klient = kontekst.getBean(TilgangsmaskinKlient::class.java)
+        val resultater = klient.sjekkTilgangTilPersoner(listOf("12345678910"))
+
+        // Assert
+        assertThat(resultater.single().harTilgang).isTrue()
+        wiremockServer.verify(
+            postRequestedFor(urlEqualTo("/api/v1/bulk/obo"))
+                .withHeader(KLIENT_HEADER, equalTo("tilgangsmaskin"))
+                .withHeader("Content-Type", equalTo("application/json"))
+                .withHeader("Accept", equalTo("application/json")),
+        )
+        kontekst.close()
+    }
+
+    @Configuration
+    class RestClientTestConfig {
+        @Bean("tilgangsmaskinRestClient")
+        fun tilgangsmaskinRestClient(): RestClient =
+            RestClient
+                .builder()
+                .defaultHeader(KLIENT_HEADER, "tilgangsmaskin")
+                .defaultHeader("Accept", "text/plain")
+                .build()
+
+        // Finnes kun for at konteksten skal ha flere RestClient-bønner, slik testen speiler konsumentene.
+        // Uten den ville Spring injisert på type alene, og testen vært grønn selv om @Qualifier manglet.
+        @Bean("restClientSomIkkeSkalVelges")
+        fun restClientSomIkkeSkalVelges(): RestClient = RestClient.builder().defaultHeader(KLIENT_HEADER, "skal-ikke-velges").build()
+    }
+
+    companion object {
+        private const val KLIENT_HEADER = "X-Test-Klient"
+    }
+}

--- a/tilgangsmaskin-klient/src/test/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinKlientConfigTest.kt
+++ b/tilgangsmaskin-klient/src/test/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinKlientConfigTest.kt
@@ -51,7 +51,7 @@ class TilgangsmaskinKlientConfigTest {
 
         // Act
         val klient = kontekst.getBean(TilgangsmaskinKlient::class.java)
-        val resultater = klient.sjekkTilgangTilPersoner(listOf("12345678910"))
+        val resultater = klient.sjekkTilgangTilPersoner(setOf("12345678910"))
 
         // Assert
         assertThat(resultater.single().harTilgang).isTrue()
@@ -66,8 +66,8 @@ class TilgangsmaskinKlientConfigTest {
 
     @Configuration
     class RestClientTestConfig {
-        @Bean("tilgangsmaskinRestClient")
-        fun tilgangsmaskinRestClient(): RestClient =
+        @Bean("tilgangsmaskinOboRestClient")
+        fun tilgangsmaskinOboRestClient(): RestClient =
             RestClient
                 .builder()
                 .defaultHeader(KLIENT_HEADER, "tilgangsmaskin")

--- a/tilgangsmaskin-klient/src/test/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinKlientTest.kt
+++ b/tilgangsmaskin-klient/src/test/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinKlientTest.kt
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import org.springframework.web.client.RestClient
+import org.springframework.web.client.RestClientResponseException
 import tools.jackson.core.JacksonException
 import tools.jackson.databind.json.JsonMapper
 import java.net.URI
@@ -166,6 +167,25 @@ class TilgangsmaskinKlientTest {
         // Act & Assert
         assertThatThrownBy { tilgangsmaskinKlient.sjekkTilgangTilPersoner(listOf("12345678910")) }
             .isInstanceOf(TilgangsmaskinException::class.java)
+    }
+
+    @Test
+    fun `skal ikke ta med responsbodyen i exception-meldingen fordi den kan inneholde personidenter`() {
+        // Arrange
+        wiremockServer.stubFor(
+            post(urlEqualTo(BULK_PATH)).willReturn(
+                aResponse()
+                    .withStatus(400)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("""{ "detail": "Ugyldig brukerId 12345678910" }"""),
+            ),
+        )
+
+        // Act & Assert
+        assertThatThrownBy { tilgangsmaskinKlient.sjekkTilgangTilPersoner(listOf("12345678910")) }
+            .isInstanceOf(TilgangsmaskinException::class.java)
+            .hasMessage("Feil ved kall mot Tilgangsmaskinen: HTTP 400")
+            .hasRootCauseInstanceOf(RestClientResponseException::class.java)
     }
 
     @Test

--- a/tilgangsmaskin-klient/src/test/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinKlientTest.kt
+++ b/tilgangsmaskin-klient/src/test/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinKlientTest.kt
@@ -1,0 +1,319 @@
+package no.nav.familie.tilgangsmaskin
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.containing
+import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.web.client.RestClient
+import tools.jackson.core.JacksonException
+import tools.jackson.databind.json.JsonMapper
+import java.net.URI
+
+class TilgangsmaskinKlientTest {
+    private lateinit var wiremockServer: WireMockServer
+    private lateinit var tilgangsmaskinKlient: TilgangsmaskinKlient
+
+    @BeforeEach
+    fun setUp() {
+        wiremockServer = WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort().http2PlainDisabled(true))
+        wiremockServer.start()
+        tilgangsmaskinKlient =
+            TilgangsmaskinKlient(
+                tilgangsmaskinUri = URI.create(wiremockServer.baseUrl()),
+                restClient = RestClient.builder().build(),
+            )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        wiremockServer.stop()
+    }
+
+    @Test
+    fun `skal gi tilgang når Tilgangsmaskinen svarer 204 for personen`() {
+        // Arrange
+        stubBulk("""{ "ansattId": "Z999999", "resultater": [ { "brukerId": "12345678910", "status": 204 } ] }""")
+
+        // Act
+        val resultater = tilgangsmaskinKlient.sjekkTilgangTilPersoner(listOf("12345678910"))
+
+        // Assert
+        assertThat(resultater).hasSize(1)
+        assertThat(resultater.single().harTilgang).isTrue()
+        assertThat(resultater.single().avvisningskode).isNull()
+    }
+
+    @Test
+    fun `skal beholde avvisningskode, begrunnelse, traceId og kanOverstyres ved avvisning`() {
+        // Arrange
+        stubBulk(
+            """
+            { "ansattId": "Z999999",
+              "resultater": [
+                { "brukerId": "12345678910", "status": 403,
+                  "detaljer": {
+                    "title": "AVVIST_GEOGRAFISK",
+                    "begrunnelse": "Bruker tilhører en annen enhet",
+                    "traceId": "en-trace-id",
+                    "kanOverstyres": true
+                  }
+                }
+              ] }
+            """.trimIndent(),
+        )
+
+        // Act
+        val resultat = tilgangsmaskinKlient.sjekkTilgangTilPersoner(listOf("12345678910")).single()
+
+        // Assert
+        assertThat(resultat.harTilgang).isFalse()
+        assertThat(resultat.avvisningskode).isEqualTo(Avvisningskode.AVVIST_GEOGRAFISK)
+        assertThat(resultat.begrunnelse).isEqualTo("Bruker tilhører en annen enhet")
+        assertThat(resultat.traceId).isEqualTo("en-trace-id")
+        assertThat(resultat.kanOverstyres).isTrue()
+    }
+
+    @Test
+    fun `skal tolke ukjent avvisningskode som UKJENT i stedet for å feile`() {
+        // Arrange
+        stubBulk(
+            """
+            { "ansattId": "Z999999",
+              "resultater": [
+                { "brukerId": "12345678910", "status": 403,
+                  "detaljer": { "title": "EN_HELT_NY_KODE", "begrunnelse": "Ny regel", "ukjentFelt": "verdi" } }
+              ] }
+            """.trimIndent(),
+        )
+
+        // Act
+        val resultat = tilgangsmaskinKlient.sjekkTilgangTilPersoner(listOf("12345678910")).single()
+
+        // Assert
+        assertThat(resultat.harTilgang).isFalse()
+        assertThat(resultat.avvisningskode).isEqualTo(Avvisningskode.UKJENT)
+        assertThat(resultat.begrunnelse).isEqualTo("Ny regel")
+    }
+
+    @Test
+    fun `skal nekte tilgang for ident som Tilgangsmaskinen ikke svarer for`() {
+        // Arrange
+        stubBulk("""{ "ansattId": "Z999999", "resultater": [ { "brukerId": "11111111111", "status": 204 } ] }""")
+
+        // Act
+        val resultater = tilgangsmaskinKlient.sjekkTilgangTilPersoner(listOf("11111111111", "22222222222"))
+
+        // Assert
+        assertThat(resultater).hasSize(2)
+        assertThat(resultater.single { it.personIdent == "11111111111" }.harTilgang).isTrue()
+        assertThat(resultater.single { it.personIdent == "22222222222" }.harTilgang).isFalse()
+        assertThat(resultater.single { it.personIdent == "22222222222" }.begrunnelse)
+            .isEqualTo("Fikk ikke svar fra Tilgangsmaskinen for personen")
+    }
+
+    @Test
+    fun `skal returnere ett resultat per etterspurt ident også når samme ident sendes inn flere ganger`() {
+        // Arrange
+        stubBulk("""{ "ansattId": "Z999999", "resultater": [ { "brukerId": "12345678910", "status": 204 } ] }""")
+
+        // Act
+        val resultater = tilgangsmaskinKlient.sjekkTilgangTilPersoner(listOf("12345678910", "12345678910"))
+
+        // Assert
+        assertThat(resultater).hasSize(2)
+        assertThat(resultater).allMatch { it.harTilgang }
+    }
+
+    @Test
+    fun `skal dele opp i flere kall når det er flere enn maks antall identer`() {
+        // Arrange
+        val identer = (1..TilgangsmaskinKlient.MAKS_ANTALL_IDENTER_PER_KALL + 1).map { it.toString().padStart(11, '0') }
+        stubBulk("""{ "ansattId": "Z999999", "resultater": [] }""")
+
+        // Act
+        tilgangsmaskinKlient.sjekkTilgangTilPersoner(identer)
+
+        // Assert
+        wiremockServer.verify(2, postRequestedFor(urlEqualTo(BULK_PATH)))
+    }
+
+    @Test
+    fun `skal ikke kalle Tilgangsmaskinen når det ikke er noen identer å sjekke`() {
+        // Act
+        val resultater = tilgangsmaskinKlient.sjekkTilgangTilPersoner(emptyList())
+
+        // Assert
+        assertThat(resultater).isEmpty()
+        wiremockServer.verify(0, postRequestedFor(urlEqualTo(BULK_PATH)))
+    }
+
+    @Test
+    fun `skal kaste TilgangsmaskinException når Tilgangsmaskinen feiler`() {
+        // Arrange
+        wiremockServer.stubFor(post(urlEqualTo(BULK_PATH)).willReturn(aResponse().withStatus(500)))
+
+        // Act & Assert
+        assertThatThrownBy { tilgangsmaskinKlient.sjekkTilgangTilPersoner(listOf("12345678910")) }
+            .isInstanceOf(TilgangsmaskinException::class.java)
+    }
+
+    @Test
+    fun `skal nekte tilgang for ukjent person som Tilgangsmaskinen svarer 404 for`() {
+        // Arrange
+        // Tilgangsmaskinen har en egen kategori for ukjente personer (AggregertBulkRespons.ukjente = 404).
+        stubBulk("""{ "resultater": [ { "brukerId": "12345678910", "status": 404 } ] }""")
+
+        // Act
+        val resultat = tilgangsmaskinKlient.sjekkTilgangTilPersoner(listOf("12345678910")).single()
+
+        // Assert
+        assertThat(resultat.harTilgang).isFalse()
+        assertThat(resultat.httpStatus).isEqualTo(404)
+        assertThat(resultat.avvisningskode).isEqualTo(Avvisningskode.UKJENT)
+    }
+
+    @Test
+    fun `skal takle avvisning uten title uten å feile`() {
+        // Arrange
+        // title er nullable uten defaultverdi. Fravær skal gi null (og dermed UKJENT), ikke deserialiseringsfeil.
+        stubBulk(
+            """{ "resultater": [ { "brukerId": "12345678910", "status": 403, "detaljer": { "begrunnelse": "Ingen kode" } } ] }""",
+        )
+
+        // Act
+        val resultat = tilgangsmaskinKlient.sjekkTilgangTilPersoner(listOf("12345678910")).single()
+
+        // Assert
+        assertThat(resultat.harTilgang).isFalse()
+        assertThat(resultat.avvisningskode).isEqualTo(Avvisningskode.UKJENT)
+        assertThat(resultat.begrunnelse).isEqualTo("Ingen kode")
+    }
+
+    @Test
+    fun `skal ikke la en tom ident velte tilgangssjekken for de gyldige identene`() {
+        // Arrange
+        // Tilgangsmaskinen avviser hele forespørselen med 400 dersom én brukerId er tom.
+        stubBulk("""{ "resultater": [ { "brukerId": "12345678910", "status": 204 } ] }""")
+
+        // Act
+        val resultater = tilgangsmaskinKlient.sjekkTilgangTilPersoner(listOf("12345678910", "  "))
+
+        // Assert
+        assertThat(resultater).hasSize(2)
+        assertThat(resultater.first().harTilgang).isTrue()
+        assertThat(resultater.last().harTilgang).isFalse()
+        assertThat(resultater.last().httpStatus).isEqualTo(400)
+        wiremockServer.verify(
+            postRequestedFor(urlEqualTo(BULK_PATH))
+                .withRequestBody(equalToJson("""[ { "brukerId": "12345678910", "type": "KJERNE_REGELTYPE" } ]""")),
+        )
+    }
+
+    @Test
+    fun `skal ikke kalle Tilgangsmaskinen når alle identene er tomme`() {
+        // Act
+        val resultater = tilgangsmaskinKlient.sjekkTilgangTilPersoner(listOf(""))
+
+        // Assert
+        assertThat(resultater).hasSize(1)
+        assertThat(resultater.single().harTilgang).isFalse()
+        wiremockServer.verify(0, postRequestedFor(urlEqualTo(BULK_PATH)))
+    }
+
+    @Test
+    fun `skal sende brukerId og regeltype i forespørselen`() {
+        // Arrange
+        stubBulk("""{ "ansattId": "Z999999", "resultater": [ { "brukerId": "12345678910", "status": 204 } ] }""")
+
+        // Act
+        tilgangsmaskinKlient.sjekkTilgangTilPersoner(listOf("12345678910"), Regeltype.KOMPLETT_REGELTYPE)
+
+        // Assert
+        wiremockServer.verify(
+            postRequestedFor(urlEqualTo(BULK_PATH))
+                .withRequestBody(
+                    equalToJson("""[ { "brukerId": "12345678910", "type": "KOMPLETT_REGELTYPE" } ]"""),
+                ),
+        )
+    }
+
+    @Test
+    fun `skal slå sammen resultater fra alle chunkene`() {
+        // Arrange
+        val forsteChunk = (1..TilgangsmaskinKlient.MAKS_ANTALL_IDENTER_PER_KALL).map { it.toString().padStart(11, '0') }
+        val sisteIdent = "99999999999"
+        wiremockServer.stubFor(
+            post(urlEqualTo(BULK_PATH))
+                .withRequestBody(containing(sisteIdent))
+                .willReturn(bulkRespons("""{ "resultater": [ { "brukerId": "$sisteIdent", "status": 204 } ] }""")),
+        )
+        wiremockServer.stubFor(
+            post(urlEqualTo(BULK_PATH))
+                .withRequestBody(containing(forsteChunk.first()))
+                .willReturn(
+                    bulkRespons("""{ "resultater": [ { "brukerId": "${forsteChunk.first()}", "status": 204 } ] }"""),
+                ),
+        )
+
+        // Act
+        val resultater = tilgangsmaskinKlient.sjekkTilgangTilPersoner(forsteChunk + sisteIdent)
+
+        // Assert
+        wiremockServer.verify(2, postRequestedFor(urlEqualTo(BULK_PATH)))
+        assertThat(resultater.single { it.personIdent == forsteChunk.first() }.harTilgang).isTrue()
+        assertThat(resultater.single { it.personIdent == sisteIdent }.harTilgang).isTrue()
+    }
+
+    @Test
+    fun `skal sende ett kall når det er nøyaktig maks antall identer`() {
+        // Arrange
+        val identer = (1..TilgangsmaskinKlient.MAKS_ANTALL_IDENTER_PER_KALL).map { it.toString().padStart(11, '0') }
+        stubBulk("""{ "resultater": [] }""")
+
+        // Act
+        tilgangsmaskinKlient.sjekkTilgangTilPersoner(identer)
+
+        // Assert
+        wiremockServer.verify(1, postRequestedFor(urlEqualTo(BULK_PATH)))
+    }
+
+    @Test
+    fun `skal feile høylytt i stedet for stille dersom Kotlin-modulen mangler på ObjectMapperen`() {
+        // Arrange
+        // Har alle felt i en data class defaultverdi, lager Kotlin en syntetisk no-arg-konstruktør som Jackson
+        // foretrekker uten Kotlin-modulen. Da ville vi fått tomme felter uten feilmelding. Denne testen låser
+        // at DTO-ene ikke har den fellen.
+        val mapperUtenKotlinModul = JsonMapper.builder().build()
+        val json = """{ "ansattId": "Z999999", "resultater": [ { "brukerId": "12345678910", "status": 204 } ] }"""
+
+        // Act & Assert
+        assertThatThrownBy { mapperUtenKotlinModul.readValue(json, TilgangsmaskinBulkResponsDto::class.java) }
+            .isInstanceOf(JacksonException::class.java)
+    }
+
+    private fun stubBulk(respons: String) {
+        wiremockServer.stubFor(post(urlEqualTo(BULK_PATH)).willReturn(bulkRespons(respons)))
+    }
+
+    // Tilgangsmaskinen svarer 207 MULTI_STATUS paa bulk-endepunktet, ikke 200.
+    private fun bulkRespons(respons: String): ResponseDefinitionBuilder =
+        aResponse()
+            .withStatus(HttpStatus.MULTI_STATUS.value())
+            .withHeader("Content-Type", "application/json")
+            .withBody(respons)
+
+    companion object {
+        private const val BULK_PATH = "/api/v1/bulk/obo"
+    }
+}

--- a/tilgangsmaskin-klient/src/test/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinKlientTest.kt
+++ b/tilgangsmaskin-klient/src/test/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinKlientTest.kt
@@ -26,7 +26,7 @@ class TilgangsmaskinKlientTest {
 
     @BeforeEach
     fun setUp() {
-        wiremockServer = WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort().http2PlainDisabled(true))
+        wiremockServer = WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort())
         wiremockServer.start()
         tilgangsmaskinKlient =
             TilgangsmaskinKlient(
@@ -123,7 +123,7 @@ class TilgangsmaskinKlientTest {
     }
 
     @Test
-    fun `skal returnere ett resultat per etterspurt ident også når samme ident sendes inn flere ganger`() {
+    fun `skal returnere ett resultat per unike ident når samme ident sendes inn flere ganger`() {
         // Arrange
         stubBulk("""{ "ansattId": "Z999999", "resultater": [ { "brukerId": "12345678910", "status": 204 } ] }""")
 
@@ -131,8 +131,8 @@ class TilgangsmaskinKlientTest {
         val resultater = tilgangsmaskinKlient.sjekkTilgangTilPersoner(listOf("12345678910", "12345678910"))
 
         // Assert
-        assertThat(resultater).hasSize(2)
-        assertThat(resultater).allMatch { it.harTilgang }
+        assertThat(resultater).hasSize(1)
+        assertThat(resultater.single().harTilgang).isTrue()
     }
 
     @Test
@@ -201,19 +201,17 @@ class TilgangsmaskinKlientTest {
     }
 
     @Test
-    fun `skal ikke la en tom ident velte tilgangssjekken for de gyldige identene`() {
+    fun `skal filtrere bort tomme identer og fortsatt sjekke de gyldige`() {
         // Arrange
-        // Tilgangsmaskinen avviser hele forespørselen med 400 dersom én brukerId er tom.
+        // Tilgangsmaskinen avviser hele forespørselen med 400 dersom én eneste brukerId er tom.
         stubBulk("""{ "resultater": [ { "brukerId": "12345678910", "status": 204 } ] }""")
 
         // Act
         val resultater = tilgangsmaskinKlient.sjekkTilgangTilPersoner(listOf("12345678910", "  "))
 
         // Assert
-        assertThat(resultater).hasSize(2)
-        assertThat(resultater.first().harTilgang).isTrue()
-        assertThat(resultater.last().harTilgang).isFalse()
-        assertThat(resultater.last().httpStatus).isEqualTo(400)
+        assertThat(resultater).hasSize(1)
+        assertThat(resultater.single().harTilgang).isTrue()
         wiremockServer.verify(
             postRequestedFor(urlEqualTo(BULK_PATH))
                 .withRequestBody(equalToJson("""[ { "brukerId": "12345678910", "type": "KJERNE_REGELTYPE" } ]""")),
@@ -226,8 +224,7 @@ class TilgangsmaskinKlientTest {
         val resultater = tilgangsmaskinKlient.sjekkTilgangTilPersoner(listOf(""))
 
         // Assert
-        assertThat(resultater).hasSize(1)
-        assertThat(resultater.single().harTilgang).isFalse()
+        assertThat(resultater).isEmpty()
         wiremockServer.verify(0, postRequestedFor(urlEqualTo(BULK_PATH)))
     }
 

--- a/tilgangsmaskin-klient/src/test/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinKlientTest.kt
+++ b/tilgangsmaskin-klient/src/test/kotlin/no/nav/familie/tilgangsmaskin/TilgangsmaskinKlientTest.kt
@@ -47,7 +47,7 @@ class TilgangsmaskinKlientTest {
         stubBulk("""{ "ansattId": "Z999999", "resultater": [ { "brukerId": "12345678910", "status": 204 } ] }""")
 
         // Act
-        val resultater = tilgangsmaskinKlient.sjekkTilgangTilPersoner(listOf("12345678910"))
+        val resultater = tilgangsmaskinKlient.sjekkTilgangTilPersoner(setOf("12345678910"))
 
         // Assert
         assertThat(resultater).hasSize(1)
@@ -75,7 +75,7 @@ class TilgangsmaskinKlientTest {
         )
 
         // Act
-        val resultat = tilgangsmaskinKlient.sjekkTilgangTilPersoner(listOf("12345678910")).single()
+        val resultat = tilgangsmaskinKlient.sjekkTilgangTilPersoner(setOf("12345678910")).single()
 
         // Assert
         assertThat(resultat.harTilgang).isFalse()
@@ -99,7 +99,7 @@ class TilgangsmaskinKlientTest {
         )
 
         // Act
-        val resultat = tilgangsmaskinKlient.sjekkTilgangTilPersoner(listOf("12345678910")).single()
+        val resultat = tilgangsmaskinKlient.sjekkTilgangTilPersoner(setOf("12345678910")).single()
 
         // Assert
         assertThat(resultat.harTilgang).isFalse()
@@ -113,7 +113,7 @@ class TilgangsmaskinKlientTest {
         stubBulk("""{ "ansattId": "Z999999", "resultater": [ { "brukerId": "11111111111", "status": 204 } ] }""")
 
         // Act
-        val resultater = tilgangsmaskinKlient.sjekkTilgangTilPersoner(listOf("11111111111", "22222222222"))
+        val resultater = tilgangsmaskinKlient.sjekkTilgangTilPersoner(setOf("11111111111", "22222222222"))
 
         // Assert
         assertThat(resultater).hasSize(2)
@@ -124,22 +124,9 @@ class TilgangsmaskinKlientTest {
     }
 
     @Test
-    fun `skal returnere ett resultat per unike ident når samme ident sendes inn flere ganger`() {
-        // Arrange
-        stubBulk("""{ "ansattId": "Z999999", "resultater": [ { "brukerId": "12345678910", "status": 204 } ] }""")
-
-        // Act
-        val resultater = tilgangsmaskinKlient.sjekkTilgangTilPersoner(listOf("12345678910", "12345678910"))
-
-        // Assert
-        assertThat(resultater).hasSize(1)
-        assertThat(resultater.single().harTilgang).isTrue()
-    }
-
-    @Test
     fun `skal dele opp i flere kall når det er flere enn maks antall identer`() {
         // Arrange
-        val identer = (1..TilgangsmaskinKlient.MAKS_ANTALL_IDENTER_PER_KALL + 1).map { it.toString().padStart(11, '0') }
+        val identer = (1..TilgangsmaskinKlient.MAKS_ANTALL_IDENTER_PER_KALL + 1).map { it.toString().padStart(11, '0') }.toSet()
         stubBulk("""{ "ansattId": "Z999999", "resultater": [] }""")
 
         // Act
@@ -152,7 +139,7 @@ class TilgangsmaskinKlientTest {
     @Test
     fun `skal ikke kalle Tilgangsmaskinen når det ikke er noen identer å sjekke`() {
         // Act
-        val resultater = tilgangsmaskinKlient.sjekkTilgangTilPersoner(emptyList())
+        val resultater = tilgangsmaskinKlient.sjekkTilgangTilPersoner(emptySet())
 
         // Assert
         assertThat(resultater).isEmpty()
@@ -165,8 +152,20 @@ class TilgangsmaskinKlientTest {
         wiremockServer.stubFor(post(urlEqualTo(BULK_PATH)).willReturn(aResponse().withStatus(500)))
 
         // Act & Assert
-        assertThatThrownBy { tilgangsmaskinKlient.sjekkTilgangTilPersoner(listOf("12345678910")) }
+        assertThatThrownBy { tilgangsmaskinKlient.sjekkTilgangTilPersoner(setOf("12345678910")) }
             .isInstanceOf(TilgangsmaskinException::class.java)
+            .hasFieldOrPropertyWithValue("httpStatus", 500)
+    }
+
+    @Test
+    fun `skal ikke sette httpStatus når feilen ikke kommer fra et HTTP-svar`() {
+        // Arrange
+        wiremockServer.stop()
+
+        // Act & Assert
+        assertThatThrownBy { tilgangsmaskinKlient.sjekkTilgangTilPersoner(setOf("12345678910")) }
+            .isInstanceOf(TilgangsmaskinException::class.java)
+            .hasFieldOrPropertyWithValue("httpStatus", null)
     }
 
     @Test
@@ -182,9 +181,10 @@ class TilgangsmaskinKlientTest {
         )
 
         // Act & Assert
-        assertThatThrownBy { tilgangsmaskinKlient.sjekkTilgangTilPersoner(listOf("12345678910")) }
+        assertThatThrownBy { tilgangsmaskinKlient.sjekkTilgangTilPersoner(setOf("12345678910")) }
             .isInstanceOf(TilgangsmaskinException::class.java)
             .hasMessage("Feil ved kall mot Tilgangsmaskinen: HTTP 400")
+            .hasFieldOrPropertyWithValue("httpStatus", 400)
             .hasRootCauseInstanceOf(RestClientResponseException::class.java)
     }
 
@@ -195,7 +195,7 @@ class TilgangsmaskinKlientTest {
         stubBulk("""{ "resultater": [ { "brukerId": "12345678910", "status": 404 } ] }""")
 
         // Act
-        val resultat = tilgangsmaskinKlient.sjekkTilgangTilPersoner(listOf("12345678910")).single()
+        val resultat = tilgangsmaskinKlient.sjekkTilgangTilPersoner(setOf("12345678910")).single()
 
         // Assert
         assertThat(resultat.harTilgang).isFalse()
@@ -212,7 +212,7 @@ class TilgangsmaskinKlientTest {
         )
 
         // Act
-        val resultat = tilgangsmaskinKlient.sjekkTilgangTilPersoner(listOf("12345678910")).single()
+        val resultat = tilgangsmaskinKlient.sjekkTilgangTilPersoner(setOf("12345678910")).single()
 
         // Assert
         assertThat(resultat.harTilgang).isFalse()
@@ -227,7 +227,7 @@ class TilgangsmaskinKlientTest {
         stubBulk("""{ "resultater": [ { "brukerId": "12345678910", "status": 204 } ] }""")
 
         // Act
-        val resultater = tilgangsmaskinKlient.sjekkTilgangTilPersoner(listOf("12345678910", "  "))
+        val resultater = tilgangsmaskinKlient.sjekkTilgangTilPersoner(setOf("12345678910", "  "))
 
         // Assert
         assertThat(resultater).hasSize(1)
@@ -241,7 +241,7 @@ class TilgangsmaskinKlientTest {
     @Test
     fun `skal ikke kalle Tilgangsmaskinen når alle identene er tomme`() {
         // Act
-        val resultater = tilgangsmaskinKlient.sjekkTilgangTilPersoner(listOf(""))
+        val resultater = tilgangsmaskinKlient.sjekkTilgangTilPersoner(setOf(""))
 
         // Assert
         assertThat(resultater).isEmpty()
@@ -254,7 +254,7 @@ class TilgangsmaskinKlientTest {
         stubBulk("""{ "ansattId": "Z999999", "resultater": [ { "brukerId": "12345678910", "status": 204 } ] }""")
 
         // Act
-        tilgangsmaskinKlient.sjekkTilgangTilPersoner(listOf("12345678910"), Regeltype.KOMPLETT_REGELTYPE)
+        tilgangsmaskinKlient.sjekkTilgangTilPersoner(setOf("12345678910"), Regeltype.KOMPLETT_REGELTYPE)
 
         // Assert
         wiremockServer.verify(
@@ -284,7 +284,7 @@ class TilgangsmaskinKlientTest {
         )
 
         // Act
-        val resultater = tilgangsmaskinKlient.sjekkTilgangTilPersoner(forsteChunk + sisteIdent)
+        val resultater = tilgangsmaskinKlient.sjekkTilgangTilPersoner((forsteChunk + sisteIdent).toSet())
 
         // Assert
         wiremockServer.verify(2, postRequestedFor(urlEqualTo(BULK_PATH)))
@@ -295,7 +295,7 @@ class TilgangsmaskinKlientTest {
     @Test
     fun `skal sende ett kall når det er nøyaktig maks antall identer`() {
         // Arrange
-        val identer = (1..TilgangsmaskinKlient.MAKS_ANTALL_IDENTER_PER_KALL).map { it.toString().padStart(11, '0') }
+        val identer = (1..TilgangsmaskinKlient.MAKS_ANTALL_IDENTER_PER_KALL).map { it.toString().padStart(11, '0') }.toSet()
         stubBulk("""{ "resultater": [] }""")
 
         // Act


### PR DESCRIPTION
Legger til modulen `tilgangsmaskin-klient` for oppslag mot Tilgangsmaskinen (populasjonstilgangskontroll), slik at appene slipper å skrive den samme klienten hver for seg.

Bakgrunn: NAV-27897. Vurderingen var å kalle Tilgangsmaskinen direkte fra hver app framfor å proxye via familie-integrasjoner, med delt klientkode her.

## Tiltenkt bruk

Biblioteket eier protokollen — DTO-er, bulk-endepunktet og oppdeling i bolker. Konsumenten eier autentiseringen, siden scope og tokenveksling er appspesifikt.

**1. Legg til avhengigheten:**

```xml
<dependency>
    <groupId>no.nav.familie.felles</groupId>
    <artifactId>tilgangsmaskin-klient</artifactId>
</dependency>
```

**2. Lag en `RestClient` med riktig scope og OBO-token, under navnet `tilgangsmaskinOboRestClient`:**

```kotlin
@Bean("tilgangsmaskinOboRestClient")
fun tilgangsmaskinOboRestClient(
    @Value("\${TILGANGSMASKIN_SCOPE}") scope: String,
): RestClient =
    entraIDRestClientFactory.lagOboRestKlient(scope) {
        SikkerhetContext.hentJwt()?.tokenValue
    }
```

Navnet sier *obo* fordi bulk-endepunktet krever OBO-token — bruk `lagOboRestKlient`, ikke en client credentials- eller hybrid-klient.

**3. Importer konfigurasjonen:**

```kotlin
@Import(TilgangsmaskinKlientConfig::class)
```

Konfigurasjonen forventer også `TILGANGSMASKIN_API_URL`. Deretter kan klienten injiseres:

```kotlin
val resultater = tilgangsmaskinKlient.sjekkTilgangTilPersoner(personIdenter)
```

`TilgangsmaskinKlient` er bevisst annotasjonsfri, så den kan konstrueres direkte der man ikke vil gå via Spring — for eksempel i fakes i integrasjonstester.

## Kontrakt

- Bulk-endepunktet krever OBO-token. NAV-identen hentes fra tokenet, så kallet kan kun gjøres i saksbehandlerkontekst.
- Identene sendes inn som `Set`, så duplikater er utelukket allerede i signaturen. Returnerer ett resultat per ikke-tom ident. Identer deles opp i bolker på 1000, som er grensen Tilgangsmaskinen setter.
- Svarer ikke Tilgangsmaskinen for en ident, returneres et resultat uten tilgang. Vi gir aldri tilgang basert på et ufullstendig svar.
- Feiler kallet, kastes `TilgangsmaskinException`. Da returneres ingen resultater i det hele tatt, og konsumenten må behandle unntaket som manglende tilgang. `httpStatus` er satt på unntaket når feilen kom fra et HTTP-svar, slik at konsumenten kan skille klientfeil (4xx) fra serverfeil (5xx).
`avvisningskode` er `null` når tilgang er innvilget, slik at "innvilget" og "avvist av ukjent grunn" ikke kan forveksles. `kanOverstyres` er tatt vare på, siden konsumenten ellers ikke kan skille avvisninger som kan overstyres (geografi/enhet) fra dem som ikke kan det (kode 6/7, skjerming).

## Verdt å vite

- Ukjente avvisningskoder mappes til `UKJENT` framfor å feile, slik at nye koder i Tilgangsmaskinen ikke velter deserialiseringen. Klienten logger en `WARN` med den ukjente koden — loggen inneholder aldri personidenter.
- Enkelte DTO-felter har bevisst ingen defaultverdi. Får alle konstruktørparametrene i en Kotlin data class en default, genererer Kotlin en syntetisk no-arg-konstruktør som Jackson foretrekker dersom Kotlin-modulen ikke er registrert på ObjectMapperen. Feltene ville da beholdt defaultene uten feilmelding, og vi ville nektet tilgang for alle.
- `Content-Type` og `Accept` settes i selve kallet, slik at protokollen ikke avhenger av defaults i RestClienten som sendes inn.
