### PR TITLE
Norges Bank valutakurs-klient: Bedre presisjon på valutakurs når den konverteres til valutakurs per 1 NOK.

### DIFF
--- a/valutakurs-klient/src/main/kotlin/no/nav/familie/valutakurs/domene/norgesbank/NorgesBankValutakursMapper.kt
+++ b/valutakurs-klient/src/main/kotlin/no/nav/familie/valutakurs/domene/norgesbank/NorgesBankValutakursMapper.kt
@@ -3,7 +3,6 @@ package no.nav.familie.valutakurs.domene.norgesbank
 import no.nav.familie.valutakurs.domene.Valutakurs
 import no.nav.familie.valutakurs.exception.NorgesBankValutakursMappingException
 import java.math.BigDecimal
-import java.math.RoundingMode
 import java.time.LocalDate
 import java.time.format.DateTimeParseException
 import kotlin.math.pow
@@ -96,7 +95,8 @@ object NorgesBankValutakursMapper {
      * Vi må derfor hente ut enhets-multiplikatoren med id *UNIT_MULT* og bruke denne for å kalkulere enhetsverdien.
      * Kursen kalkuleres ved (kurs / 10^UNIT_MULT). Altså vil det bli henholdsvis kurs/1, kurs/10, kurs/100 osv basert på verdien til *UNIT_MULT*.
      * Eksempelvis leveres kursen for DKK som verdien av 100 DKK og ikke 1 DKK. I dette tilfellet er *UNIT_MULT* satt til 2, og vi finner enhetsverdien ved ta kurs/100.
-     * Benytter presisjon på 10 desimaler for å unngå at desimaler forsvinner ved deling på henholdsvis 1, 10, 100 osv. Tallet 1.2345 ville blitt til tallet 0.1234 med en avrunding på 4 desimaler, men med 10 er vi trygge på at vi ikke mister viktig presisjon.
+     * Siden vi alltid deler på en potens av 10, er delingen alltid eksakt (terminerende desimaltall), og vi mister derfor aldri presisjon selv uten å oppgi eksplisitt skala eller avrundingsmodus.
+     * Resultatet får derimot ikke nødvendigvis en kompakt skala (f.eks. kan 10.0000/1 bli "10.000" i stedet for "10"), så vi bruker stripTrailingZeros() for å normalisere til et minimalt antall desimaler.
      */
     private fun NorgesBankValutakursData.tilKalkulertKurs(): BigDecimal {
         val enhetMultiplikator: Double =
@@ -107,7 +107,7 @@ object NorgesBankValutakursMapper {
         val kurs: BigDecimal = this.dataSet.series.hentKurs()
 
         return kurs
-            .divide(BigDecimal.valueOf(10.0.pow(enhetMultiplikator)), 10, RoundingMode.HALF_UP)
+            .divide(BigDecimal.valueOf(10.0.pow(enhetMultiplikator)))
             .stripTrailingZeros()
             // Passer på at scale ikke blir negativ, da dette kan føre til at 100.00 blir til 1E+2, som ikke er ønskelig.
             .let { if (it.scale() < 0) it.setScale(0) else it }

--- a/valutakurs-klient/src/main/kotlin/no/nav/familie/valutakurs/domene/norgesbank/NorgesBankValutakursMapper.kt
+++ b/valutakurs-klient/src/main/kotlin/no/nav/familie/valutakurs/domene/norgesbank/NorgesBankValutakursMapper.kt
@@ -96,7 +96,7 @@ object NorgesBankValutakursMapper {
      * Vi må derfor hente ut enhets-multiplikatoren med id *UNIT_MULT* og bruke denne for å kalkulere enhetsverdien.
      * Kursen kalkuleres ved (kurs / 10^UNIT_MULT). Altså vil det bli henholdsvis kurs/1, kurs/10, kurs/100 osv basert på verdien til *UNIT_MULT*.
      * Eksempelvis leveres kursen for DKK som verdien av 100 DKK og ikke 1 DKK. I dette tilfellet er *UNIT_MULT* satt til 2, og vi finner enhetsverdien ved ta kurs/100.
-     * Runder av kursen til 4 desimaler da det er dette vi tidligere fikk direkte fra ECB.
+     * Benytter presisjon på 10 desimaler for å unngå at desimaler forsvinner ved deling på henholdsvis 1, 10, 100 osv. Tallet 1.2345 ville blitt til tallet 0.1234 med en avrunding på 4 desimaler, men med 10 er vi trygge på at vi ikke mister viktig presisjon.
      */
     private fun NorgesBankValutakursData.tilKalkulertKurs(): BigDecimal {
         val enhetMultiplikator: Double =
@@ -106,6 +106,10 @@ object NorgesBankValutakursMapper {
 
         val kurs: BigDecimal = this.dataSet.series.hentKurs()
 
-        return kurs.divide(BigDecimal.valueOf(10.0.pow(enhetMultiplikator)), 4, RoundingMode.HALF_UP)
+        return kurs
+            .divide(BigDecimal.valueOf(10.0.pow(enhetMultiplikator)), 10, RoundingMode.HALF_UP)
+            .stripTrailingZeros()
+            // Passer på at scale ikke blir negativ, da dette kan føre til at 100.00 blir til 1E+2, som ikke er ønskelig.
+            .let { if (it.scale() < 0) it.setScale(0) else it }
     }
 }

--- a/valutakurs-klient/src/test/kotlin/no/nav/familie/valutakurs/domene/norgesbank/NorgesBankValutakursMapperTest.kt
+++ b/valutakurs-klient/src/test/kotlin/no/nav/familie/valutakurs/domene/norgesbank/NorgesBankValutakursMapperTest.kt
@@ -33,7 +33,61 @@ class NorgesBankValutakursMapperTest {
 
             // Assert
             assertEquals(valuta, valutakurs.valuta)
-            assertEquals(BigDecimal("10.0000"), valutakurs.kurs)
+            assertEquals(BigDecimal("10"), valutakurs.kurs)
+            assertEquals(kursDato, valutakurs.kursDato)
+        }
+
+        @Test
+        fun `Skal returnere korrekt valutakurs for gyldig data med 4 desimaler`() {
+            // Arrange
+            val valuta = "PLN"
+            val frekvens = VIRKEDAG
+            val kursDato = LocalDate.of(2023, 1, 1)
+            val kurs = BigDecimal("10.1234")
+            val data = mockNorgesBankValutakursData(valuta, frekvens, kursDato, kurs)
+
+            // Act
+            val valutakurs = data.tilValutakurs(valuta, frekvens, kursDato)
+
+            // Assert
+            assertEquals(valuta, valutakurs.valuta)
+            assertEquals(BigDecimal("10.1234"), valutakurs.kurs)
+            assertEquals(kursDato, valutakurs.kursDato)
+        }
+
+        @Test
+        fun `Skal returnere korrekt valutakurs for gyldig data med 8 desimaler`() {
+            // Arrange
+            val valuta = "PLN"
+            val frekvens = VIRKEDAG
+            val kursDato = LocalDate.of(2023, 1, 1)
+            val kurs = BigDecimal("10.12345678")
+            val data = mockNorgesBankValutakursData(valuta, frekvens, kursDato, kurs)
+
+            // Act
+            val valutakurs = data.tilValutakurs(valuta, frekvens, kursDato)
+
+            // Assert
+            assertEquals(valuta, valutakurs.valuta)
+            assertEquals(BigDecimal("10.12345678"), valutakurs.kurs)
+            assertEquals(kursDato, valutakurs.kursDato)
+        }
+
+        @Test
+        fun `Skal returnere korrekt valutakurs for gyldig data med UNIT_MULT 2 og 4 desimaler`() {
+            // Arrange
+            val valuta = "HUF"
+            val frekvens = VIRKEDAG
+            val kursDato = LocalDate.of(2026, 8, 18)
+            val kurs = BigDecimal("0.1234")
+            val data = mockNorgesBankValutakursData(valuta, frekvens, kursDato, kurs, unitMult = "2")
+
+            // Act
+            val valutakurs = data.tilValutakurs(valuta, frekvens, kursDato)
+
+            // Assert
+            assertEquals(valuta, valutakurs.valuta)
+            assertEquals(BigDecimal("0.001234"), valutakurs.kurs)
             assertEquals(kursDato, valutakurs.kursDato)
         }
 
@@ -132,7 +186,7 @@ class NorgesBankValutakursMapperTest {
             val valutakurs = data.tilValutakurs("PLN", VIRKEDAG, LocalDate.of(2023, 1, 1))
 
             // Assert
-            assertEquals(BigDecimal("1.0000"), valutakurs.kurs)
+            assertEquals(BigDecimal("1"), valutakurs.kurs)
         }
 
         @Test


### PR DESCRIPTION
Noen valutakurser leveres per 10 NOK eller 100 NOK. Når dette skjer konverterer vi kursen til en kurs per 1 NOK ved å dele på henholdsvis 10 og 100. Tidligere hadde vi en presisjon på 4 desimaler etter denne konverteringen. Problemet med det er at dersom en valutakurs har 4 desimaler eller mer fra Norges Bank, og vi deler på 10 eller 100 for så å runde av til 4 desimaler så kan vi miste 1 eller flere viktige desimaler.

Eks:
Tallet 1.1234 som er en kurs per 100 NOK, vil bli til 0.0112 per 1 NOK og ikke 0.011234 per 1 NOK, som er mye mer presist. 

Fjerner her `scale` fra `divide`-kallet da deling på en potens av 10 ikke vil føre til noe tap av presisjon. 1.1234 vil eksempelvis bli 0.011234 ved deling på 100 uten at vi må spesifisere presisjon.